### PR TITLE
Fix Typo in code example

### DIFF
--- a/docs/landing-page/basic-usage/basic-usage.md
+++ b/docs/landing-page/basic-usage/basic-usage.md
@@ -69,7 +69,7 @@ Regressors     Parameters        ERR
 plot_results(y=y_valid, yhat=yhat, n=1000)
 ee = compute_residues_autocorrelation(y_valid, yhat)
 plot_residues_correlation(data=ee, title="Residues", ylabel="$e^2$")
-x1e = compute_cross_correlation(y_valid, yhat, x2_val)
+x1e = compute_cross_correlation(y_valid, yhat, x_valid)
 plot_residues_correlation(data=x1e, title="Residues", ylabel="$x_1e$")
 ```
 


### PR DESCRIPTION
Example code in Basic Usage/Build a Polynomial NARX model has a typo in compute_cross_correlation that gives an error when executed since variable used does not exist