### PR TITLE
Fix readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -121,26 +121,33 @@ x_train, x_valid, y_train, y_valid = get_siso_data(
 )
 ```
 
+
 #### Building Polynomial NARX models with FROLS algorithm
 
 ```python
 from sysidentpy.model_structure_selection import FROLS
-from sysidentpy.basis_function import Polynomial
+from sysidentpy.basis_function._basis_function import Polynomial
+from sysidentpy.parameter_estimation import LeastSquares
+from sysidentpy.metrics import root_relative_squared_error
+from sysidentpy.utils.generate_data import get_siso_data
 from sysidentpy.utils.display_results import results
 from sysidentpy.utils.plotting import plot_residues_correlation, plot_results
-from sysidentpy.residues.residues_correlation import compute_residues_autocorrelation
-from sysidentpy.residues.residues_correlation import compute_cross_correlation
+from sysidentpy.residues.residues_correlation import (
+    compute_residues_autocorrelation,
+    compute_cross_correlation,
+)
 
-basis_function=Polynomial(degree=2)
+basis_function = Polynomial(degree=2)
+estimator = LeastSquares()
 model = FROLS(
-  order_selection=True,
-  n_info_values=10,
-  extended_least_squares=False,
-  ylag=2,
-  xlag=2,
-  info_criteria='aic',
-  estimator='least_squares',
-  basis_function=basis_function
+    order_selection=True,
+    n_info_values=3,
+    ylag=2,
+    xlag=2,
+    info_criteria="aic",
+    estimator=estimator,
+    err_tol=None,
+    basis_function=basis_function,
 )
 model.fit(X=x_train, y=y_train)
 yhat = model.predict(X=x_valid, y=y_valid)
@@ -154,11 +161,14 @@ r = pd.DataFrame(
 	columns=['Regressors', 'Parameters', 'ERR'])
 print(r)
 
+```
+```console
 Regressors     Parameters        ERR
 0        x1(k-2)     0.9000  0.95556574
 1         y(k-1)     0.1999  0.04107943
 2  x1(k-1)y(k-1)     0.1000  0.00335113
-
+````
+```python
 plot_results(y=y_valid, yhat=yhat, n=1000)
 ee = compute_residues_autocorrelation(y_valid, yhat)
 plot_residues_correlation(data=ee, title="Residues", ylabel="$e^2$")

--- a/docs/landing-page/basic-usage.md
+++ b/docs/landing-page/basic-usage.md
@@ -31,28 +31,35 @@ x_train, x_valid, y_train, y_valid = get_siso_data(
 
 ### Build a Polynomial NARX model
 
-``` py
+``` python
 from sysidentpy.model_structure_selection import FROLS
 from sysidentpy.basis_function._basis_function import Polynomial
+from sysidentpy.parameter_estimation import LeastSquares
+from sysidentpy.metrics import root_relative_squared_error
+from sysidentpy.utils.generate_data import get_siso_data
 from sysidentpy.utils.display_results import results
 from sysidentpy.utils.plotting import plot_residues_correlation, plot_results
-from sysidentpy.residues.residues_correlation import compute_residues_autocorrelation, compute_cross_correlation
+from sysidentpy.residues.residues_correlation import (
+    compute_residues_autocorrelation,
+    compute_cross_correlation,
+)
 
 basis_function = Polynomial(degree=2)
+estimator = LeastSquares()
 model = FROLS(
-	order_selection=True,
-	n_info_values=10,
-	extended_least_squares=False,
-	ylag=2,
-	xlag=2,
-	info_criteria='aic',
-	estimator='least_squares',
-	basis_function=basis_function
+    order_selection=True,
+    n_info_values=3,
+    ylag=2,
+    xlag=2,
+    info_criteria="aic",
+    estimator=estimator,
+    err_tol=None,
+    basis_function=basis_function,
 )
 model.fit(X=x_train, y=y_train)
 yhat = model.predict(X=x_valid, y=y_valid)
-mse = mean_squared_error(y_valid, yhat)
-print(mse)
+rrse = root_relative_squared_error(y_valid, yhat)
+print(rrse)
 r = pd.DataFrame(
 	results(
 		model.final_model, model.theta, model.err,
@@ -60,11 +67,14 @@ r = pd.DataFrame(
 		),
 	columns=['Regressors', 'Parameters', 'ERR'])
 print(r)
-
+```
+``` console
 Regressors     Parameters        ERR
 0        x1(k-2)     0.9000  0.95556574
 1         y(k-1)     0.1999  0.04107943
 2  x1(k-1)y(k-1)     0.1000  0.00335113
+```
+``` python
 
 plot_results(y=y_valid, yhat=yhat, n=1000)
 ee = compute_residues_autocorrelation(y_valid, yhat)


### PR DESCRIPTION
Thanks for supporting this nice toolbox!

I noticed, that when following the README, the example for **Building Polynomial NARX models with FROLS algorithm** does not work since the changes for v0.4.

In the official examples this has already been fixed with commit d41c7e287e95313c5f9b6cbecad026dc2c5bc054 .

This merge request aligns the example from `examples/basic_steps.ipynb ` with the README.

The same fix has been applied to `docs/landing-page/basic-usage.md` in order to update the docs.

Please let me know if I missed another spot, where there is still the old version.