### PR TITLE
fix check_arrays call in docs

### DIFF
--- a/docs/user-guide/API/utils.md
+++ b/docs/user-guide/API/utils.md
@@ -4,7 +4,7 @@ template: overrides/main.html
 
 # Documentation for `Neural NARX`
 
-::: sysidentpy.utils._check_arrays
+::: sysidentpy.utils.check_arrays
       show_root_heading: false
 
 ::: sysidentpy.utils.display_results


### PR DESCRIPTION
Remove underscore related to the previous protected member