### PR TITLE
add a how to guide to translations

### DIFF
--- a/docs/en/developer-guide/how-to-add-a-translation.md
+++ b/docs/en/developer-guide/how-to-add-a-translation.md
@@ -1,0 +1,262 @@
+---
+template: overrides/main.html
+title: How to Add a Translation
+---
+
+# How to Add a Translation
+
+This page explains how to add or improve a translation of the docs for **any** language.
+
+The site uses MkDocs + Material + `mkdocs-static-i18n`. English is the reference (fallback). Any other language mirrors its folder structure. If a page is missing in a target language, the English version is shown automatically.
+
+---
+## 1. Overview
+
+There are three typical scenarios:
+
+1. Improve an existing translated page.
+2. Translate an English page that currently has no localized version.
+3. Add an entirely new language to the project.
+
+Everything below covers all three.
+
+---
+## 2. Folder layout
+
+```
+/docs
+  en/
+    developer-guide/
+    getting-started/
+    user-guide/
+  <locale>/
+    (mirrors the structure you translate)
+```
+
+Examples of `<locale>`: `pt`, `es`, `fr`, `de`, `it`, `ja`, `zh`, `ru`. Use short IETF / BCP‑47 language tags (no country code unless needed, e.g. `pt` vs `pt-BR` only if a regional variant is required). Keep it consistent with `mkdocs.yml`.
+
+Relative paths must match. Example:
+
+```
+English: docs/en/developer-guide/how-to-add-a-translation.md
+Spanish: docs/es/developer-guide/how-to-add-a-translation.md
+French:  docs/fr/developer-guide/how-to-add-a-translation.md
+```
+
+---
+## 3. Quick start (improving or adding a translation)
+
+1. Fork and clone your fork.
+2. Create / activate a virtual environment.
+3. Install docs extras:
+    ```console
+    pip install -e ".[docs]"
+    ```
+4. Run the local server:
+    ```console
+    mkdocs serve
+    ```
+5. Open the local URL and switch language with the selector.
+
+Restart the server if new files do not show up (MkDocs sometimes needs a restart after new file additions).
+
+---
+## 4. Adding a new language (one-time setup)
+
+If the language already exists (e.g. `pt/`), skip this section.
+
+1. Pick a locale code (e.g. `es`).
+2. Create the folder: `docs/es/`.
+3. Copy the English `index.md` to `docs/es/index.md` and translate its visible text.
+4. (Optional) Start by copying only a minimal subset (index + key getting-started pages) to keep the first PR reviewable.
+5. Update `mkdocs.yml` `i18n.languages` section:
+    ```yaml
+    - locale: es
+      name: Español
+      build: true
+      site_description: <translated site tagline>
+      theme:
+        docs_dir: docs/es/
+        custom_dir: docs/es/
+        site_dir: site/es/
+        logo: overrides/assets/img/logotype-sysidentpy.svg
+    ```
+6. Do **not** duplicate nav entries for the new language: the plugin maps them automatically based on folder structure.
+7. Run `mkdocs serve` and confirm the new language appears in the selector.
+
+If you need a regional variant (e.g. `pt-BR`), use that code consistently in both folder name and `mkdocs.yml`.
+
+---
+## 5. Adding a new English page (source language)
+
+1. Create the file under `docs/en/...` in the right section.
+2. Add front matter:
+    ```md
+    ---
+    template: overrides/main.html
+    title: My Page Title
+    ---
+    ```
+3. Add its path to the `nav` tree in `mkdocs.yml` (English only).
+4. Verify the site builds.
+5. (Optional) Add a translator note (HTML comment) for tricky concepts:
+    ```md
+    <!-- Translator note: keep the term "NARMAX" in English. -->
+    ```
+
+---
+## 6. Creating the translated file
+
+1. Mirror the folder path: `docs/<locale>/<same relative path>.md`.
+
+2. Copy the English file.
+
+3. Translate only human-readable prose. Keep intact:
+    - Code blocks (except inline comments if clarity improves)
+    - Identifiers: function/class names, parameters, imports
+    - File paths, config keys, URLs
+    - Markdown link targets (unless they refer to a language-specific external resource)
+
+4. Preserve heading hierarchy (`#`, `##`, etc.) but translate heading text itself.
+
+5. Keep admonition types (`!!! note`, `!!! warning`, etc.). You may translate the title string after the admonition type.
+
+6. For unfinished parts, you can temporarily keep English or add:
+   ```md
+   !!! note "Pending translation"
+       This paragraph still needs translation.
+   ```
+
+7. Remove all "Pending" notes before final review if completed.
+
+---
+## 7. Internal links
+
+Use relative links without language prefixes:
+```md
+See the [Contribute guide](contribute.md).
+```
+The i18n plugin rewrites them per language. Avoid hardcoding `/en/` or another locale path unless you intentionally want a fallback link.
+
+Anchor links: if you translate a heading, Material generates a localized slug. Keep anchor usage consistent or adjust any `(#anchor)` references accordingly.
+
+---
+## 8. Images and media
+
+If screenshots contain embedded language text:
+
+- **Option A**: replicate and localize the image inside `docs/<locale>/assets/` and keep the same filename (per-locale path isolates it).
+- **Option B**: reuse the English image if text is minimal or language-agnostic.
+
+SVG diagrams: prefer keeping labels English if they are code or model symbols; translate UI captions where helpful.
+
+---
+## 9. Formatting & style guidelines
+
+| Aspect | Guideline |
+|--------|-----------|
+| Numbers | Keep numeric precision; adapt decimal separators only if standard for the target audience (optional). |
+| Units | Do not translate SI units (e.g. `ms`, `Hz`). |
+| API names | Never translate identifiers. |
+| Quotes | Follow local typographic conventions only if they do not break Markdown. |
+| Capitalization | Mirror English capitalization only where it's a proper noun or API name. |
+| Tone | Neutral, concise, instructional. |
+
+Avoid machine‑translated chunks without revision. Prefer shorter, unambiguous sentences.
+
+---
+## 10. Translation glossary
+
+Keep these terms consistent across languages. Add target language equivalents as needed:
+
+| English Term | Portuguese (pt) |
+|--------------|-----------------|
+| **Core concepts** |
+| model structure | estrutura do modelo |
+| parameter estimation | estimação de parâmetros |
+| residual analysis | análise dos resíduos |
+| time series | série temporal |
+| identification | identificação |
+| **Technical terms** |
+| basis function | função de base |
+| regression | regressão |
+| algorithm | algoritmo |
+| validation | validação |
+| simulation | simulação |
+| **Development terms** |
+| feature | funcionalidade |
+| pull request (PR) | pull request (PR) |
+| branch | branch |
+| commit | commit |
+| documentation | documentação |
+
+For other languages, follow similar patterns. Prefer clarity over literal translation.
+
+---
+## 11. Review checklist (per translated file)
+
+- [ ] Builds locally (`mkdocs serve`).
+- [ ] File path mirrors English.
+- [ ] Relative links work; no `/en/` hardcoding.
+- [ ] Code blocks untouched (except explanatory comments if needed).
+- [ ] Terminology consistent with existing pages.
+- [ ] No leftover placeholder notes (unless intentionally partial PR).
+- [ ] Front matter present and `title:` localized.
+
+---
+## 12. Commit & Pull Request
+
+Add both English and translated files if you introduce a page + its translation; otherwise just the translated file.
+
+Example:
+```console
+git add docs/en/developer-guide/new-topic.md docs/es/developer-guide/new-topic.md
+git commit -m "docs: add Spanish translation for new-topic"
+```
+
+PR description template:
+
+- **Language**: `<locale>` (e.g. `es`)
+- **Pages added/updated**: list paths
+- **Sections intentionally left untranslated**: (if any)
+- **Glossary additions**: (if any)
+- **Notes for reviewer**: context, tricky terms
+
+Partial translations are acceptable—label them clearly so others can help.
+
+---
+## 13. Updating existing translations
+
+When an English page changes:
+
+1. Open the diff to see what changed.
+2. Apply equivalent edits to the translated file.
+3. If you cannot translate immediately, keep the English change and add a temporary "Pending translation" note.
+4. Remove the note once updated.
+
+Aim for incremental PRs rather than large rewrites.
+
+---
+## 14. Common issues
+
+| Symptom | Cause | Fix |
+|---------|-------|-----|
+| Page shows in English only | Missing localized file or wrong path | Mirror path under new locale folder |
+| Build error after adding language | Misconfigured `i18n.languages` entry | Re-check `locale` key + indentation |
+| 404 on internal link | Link path differs from English | Match relative path to English version |
+| Broken anchor | Heading translated; old anchor used | Update anchor or keep similar heading slug |
+| Language not in selector | Forgot to add language in `mkdocs.yml` | Add `locale` entry and restart server |
+
+---
+## 15. Automation (optional)
+
+You may use external CAT / translation tools, but always manually review technical terms. Avoid committing raw machine output.
+
+If you script copying English files to a new locale, exclude already translated ones to prevent overwriting.
+
+---
+## 16. Questions & support
+
+If you are unsure about terminology, open an Issue or Discussion before translating large sections. Early feedback prevents rework.
+
+Thanks for helping make the documentation accessible to more people.

--- a/docs/pt/developer-guide/how-to-add-a-translation.md
+++ b/docs/pt/developer-guide/how-to-add-a-translation.md
@@ -1,0 +1,260 @@
+---
+template: overrides/main.html
+title: Como Adicionar uma Tradução
+---
+
+# Como Adicionar uma Tradução
+
+Guia para criar ou melhorar traduções da documentação em **qualquer** idioma.
+
+Usamos MkDocs + Material + `mkdocs-static-i18n`. Inglês é o fallback. Qualquer idioma novo replica a estrutura de pastas. Se faltar uma página traduzida, aparece a versão inglesa.
+
+---
+## 1. Visão geral
+
+Três cenários comuns:
+
+1. Melhorar uma página já traduzida.
+2. Traduzir uma página que só existe em inglês.
+3. Adicionar um idioma totalmente novo.
+
+Tudo abaixo cobre esses casos.
+
+---
+## 2. Estrutura de pastas
+
+```
+/docs
+  en/
+    developer-guide/
+    getting-started/
+    user-guide/
+  <locale>/
+    (mesmos caminhos relativos)
+```
+
+`<locale>` exemplos: `pt`, `es`, `fr`, `de`, `it`, `ja`, `zh`, `ru`. Use códigos curtos (BCP‑47). Evite variantes regionais salvo necessidade (`pt-BR`, `pt-PT`).
+
+Os caminhos relativos devem ser idênticos:
+
+```
+Inglês: docs/en/developer-guide/how-to-add-a-translation.md
+Espanhol: docs/es/developer-guide/how-to-add-a-translation.md
+Francês:  docs/fr/developer-guide/how-to-add-a-translation.md
+```
+
+---
+## 3. Início rápido (traduzir ou melhorar)
+
+1. Fork e clone.
+2. Crie / ative ambiente virtual.
+3. Instale extras de docs:
+    ```console
+    pip install -e ".[docs]"
+    ```
+4. Servidor local:
+    ```console
+    mkdocs serve
+    ```
+5. Abra a URL e use o seletor de idioma.
+
+Reinicie se arquivos novos não aparecerem.
+
+---
+## 4. Adicionando um novo idioma (setup inicial)
+
+Se a pasta já existe (ex: `pt/`), pule.
+
+1. Escolha código (ex: `es`).
+2. Crie `docs/es/`.
+3. Copie `docs/en/index.md` para `docs/es/index.md` e traduza.
+4. (Opcional) Comece só com index + páginas principais para PR menor.
+5. Edite `mkdocs.yml` em `i18n.languages`:
+    ```yaml
+    - locale: es
+      name: Español
+      build: true
+      site_description: <slogan traduzido>
+      theme:
+        docs_dir: docs/es/
+        custom_dir: docs/es/
+        site_dir: site/es/
+        logo: overrides/assets/img/logotype-sysidentpy.svg
+    ```
+6. Não duplique a navegação; o plugin mapeia automaticamente.
+7. Rode `mkdocs serve` e confirme o idioma no seletor.
+
+Para variantes regionais (ex: `pt-BR`) mantenha consistência no nome da pasta e no `locale`.
+
+---
+## 5. Nova página em inglês (fonte)
+
+1. Crie em `docs/en/...`.
+2. Front matter:
+    ```md
+    ---
+    template: overrides/main.html
+    title: Título
+    ---
+    ```
+3. Adicione no `nav` do `mkdocs.yml` (apenas uma vez).
+4. Verifique build.
+5. (Opcional) Comentário para tradutores:
+    ```md
+    <!-- Nota para tradução: manter "NARMAX" em inglês. -->
+    ```
+
+---
+## 6. Criando o arquivo traduzido
+
+1. Caminho espelhado: `docs/<locale>/<mesmo>.md`.
+
+2. Copie o original.
+
+3. Traduza só texto natural. Preserve:
+    - Blocos de código (comentários apenas se ajudar)
+    - Identificadores (funções, classes, imports)
+    - Caminhos, chaves de config, URLs
+    - Alvos de links relativos
+
+4. Mantenha hierarquia de títulos.
+
+5. Preserve tipos de admonitions (`!!! note`, etc.). Título interno pode ser traduzido.
+
+6. Parte pendente? Use:
+   ```md
+   !!! note "Tradução pendente"
+       Este parágrafo ainda será traduzido.
+   ```
+
+7. Remova notas pendentes antes de finalizar (se concluir).
+
+---
+## 7. Links internos
+
+Use links relativos:
+```md
+Veja o [guia de contribuição](contribute.md).
+```
+O plugin resolve por idioma. Evite hardcode `/en/` ou outro prefixo.
+
+Âncoras: se traduzir título, o slug muda; ajuste referências `(#ancora)`.
+
+---
+## 8. Imagens e mídia
+
+Se a imagem contém texto:
+
+- **Opção A**: localizar imagem dentro de `docs/<locale>/assets/` com mesmo nome.
+- **Opção B**: reutilizar imagem inglesa se o texto não atrapalha.
+
+SVG: manter símbolos ou termos técnicos; traduzir rótulos descritivos.
+
+---
+## 9. Formatação & estilo
+
+| Aspecto | Regra |
+|---------|-------|
+| Números | Mantenha precisão; separador decimal local é opcional. |
+| Unidades | Não traduzir (ms, Hz, etc.). |
+| APIs | Nunca traduzir identificadores. |
+| Aspas | Use padrão local sem quebrar Markdown. |
+| Capitalização | Igual só para nomes próprios / APIs. |
+| Tom | Neutro, direto. |
+
+Evite blocos não revisados de tradução automática. Prefira frases curtas.
+
+---
+## 10. Glossário de tradução
+
+Mantenha estes termos consistentes. Adicione equivalentes para outros idiomas conforme necessário:
+
+| Termo em Inglês | Português (pt) |
+|------------------|----------------|
+| **Conceitos centrais** |
+| model structure | estrutura do modelo |
+| parameter estimation | estimação de parâmetros |
+| residual analysis | análise dos resíduos |
+| time series | série temporal |
+| identification | identificação |
+| **Termos técnicos** |
+| basis function | função de base |
+| regression | regressão |
+| algorithm | algoritmo |
+| validation | validação |
+| simulation | simulação |
+| **Termos de desenvolvimento** |
+| feature | funcionalidade |
+| pull request (PR) | pull request (PR) |
+| branch | branch |
+| commit | commit |
+| documentation | documentação |
+
+Para outros idiomas, siga padrões similares. Prefira clareza à tradução literal.
+
+---
+## 11. Checklist de revisão (arquivo traduzido)
+
+- [ ] Build local OK.
+- [ ] Caminho espelhado correto.
+- [ ] Links relativos sem `/en/` fixo.
+- [ ] Blocos de código intactos (comentários revisados).
+- [ ] Terminologia consistente.
+- [ ] Sem notas pendentes (ou marcadas claramente se parcial).
+- [ ] Front matter com `title:` traduzido.
+
+---
+## 12. Commit & PR
+
+Inclua arquivo inglês + traduzido se a página é nova; caso contrário só o traduzido.
+
+Exemplo:
+```console
+git add docs/en/developer-guide/new-topic.md docs/es/developer-guide/new-topic.md
+git commit -m "docs: adicionar tradução em espanhol de new-topic"
+```
+
+Template de descrição de PR:
+
+- **Idioma**: `<locale>`
+- **Páginas**: lista
+- **Trechos ainda em inglês**: (se houver)
+- **Termos novos de glossário**: (se houver)
+- **Notas para revisão**: contexto, termos difíceis
+
+Traduções parciais são aceitáveis — marque claramente.
+
+---
+## 13. Atualizando traduções
+
+Quando o inglês mudar:
+
+1. Veja o diff.
+2. Aplique mudanças equivalentes.
+3. Sem tempo para traduzir? Deixe em inglês + nota temporária.
+4. Remova a nota ao finalizar.
+
+Prefira PRs menores.
+
+---
+## 14. Problemas comuns
+
+| Sintoma | Causa | Correção |
+|---------|-------|----------|
+| Página só em inglês | Falta arquivo no locale | Criar arquivo espelhado |
+| Erro de build | Entrada `i18n` incorreta | Corrigir `locale` / indentação |
+| Link 404 | Caminho diferente do inglês | Sincronizar caminho |
+| Âncora quebrada | Título mudou | Ajustar slug / título |
+| Idioma não aparece | Faltou adicionar em `mkdocs.yml` | Adicionar e reiniciar |
+
+---
+## 15. Automação (opcional)
+
+Scripts podem copiar estrutura base, mas revise manualmente termos técnicos. Não sobrescreva traduções existentes.
+
+---
+## 16. Dúvidas
+
+Abra Issue ou Discussion para confirmar termos antes de traduzir grandes trechos. Feedback cedo evita retrabalho.
+
+Obrigado por tornar a documentação acessível a mais pessoas.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -260,6 +260,7 @@ nav:
           - Documentation Overview: developer-guide/documentation-overview.md
           - How To Write a Tutorial: developer-guide/how-to-write-a-tutorial.md
           - How To Write a How-to Guide: developer-guide/how-to-write-a-how-to-guide.md
+          - How to Add a Translation: developer-guide/how-to-add-a-translation.md
   - Community & Support:
       - community-overview: community-support/community-overview.md
       - Get Help: community-support/get-help.md


### PR DESCRIPTION
## Add multilingual translation guide

### Summary
Adds comprehensive documentation for contributors who want to add or improve translations in any language. This guide provides step-by-step instructions for the existing MkDocs + Material + `mkdocs-static-i18n` setup.

### Changes
- **Added**: `docs/en/developer-guide/how-to-add-a-translation.md` - English translation guide
- **Added**: `docs/pt/developer-guide/how-to-add-a-translation.md` - Portuguese translation guide  
- **Updated**: `mkdocs.yml` - Added navigation entries under Developer Guide → Documentation

### Features
- **Language-agnostic instructions** - Works for any target language (Spanish, French, German, etc.)
- **Three main scenarios covered**:
  1. Improving existing translations
  2. Translating English-only pages
  3. Adding completely new languages
- **Comprehensive workflow** - From setup to PR submission
- **Translation glossary** - Consistent terminology (English ↔ Portuguese, extensible)
- **Troubleshooting section** - Common issues and solutions
- **Best practices** - Formatting, media handling, internal links

### Structure
The guide covers:
- Initial setup and local preview
- New language configuration in `mkdocs.yml`
- File structure mirroring (`docs/en/` → `docs/<locale>/`)
- Translation workflow and review checklist
- PR templates and commit guidelines
- Maintenance of existing translations

### Target audience
Contributors familiar with Git/GitHub who want to help translate documentation but may not be familiar with the MkDocs i18n plugin workflow.

The goal is to make the contribution process clear for international users.