### PR TITLE
docs: fix undefined variable in getting-started example (x2_val → x_valid)

### DIFF
--- a/docs/en/getting-started/quickstart-guide.md
+++ b/docs/en/getting-started/quickstart-guide.md
@@ -216,7 +216,7 @@ ee = compute_residues_autocorrelation(y_valid, yhat)
 plot_residues_correlation(data=ee, title="Residues", ylabel="$e^2$")
 
 # Compute and plot cross-correlation between residuals and an input
-x1e = compute_cross_correlation(y_valid, yhat, x2_val)
+x1e = compute_cross_correlation(y_valid, yhat, x_valid)#The final argument was previously x2_val, which was not defined in the example. Updated it to x_valid (the correct validation input) so the code runs without errors.
 plot_residues_correlation(data=x1e, title="Residues", ylabel="$x_1e$")
 ```
 


### PR DESCRIPTION
The "Getting Started" documentation example previously used `x2_val` as the final 
argument to `compute_cross_correlation`, but this variable was not defined. 

So I updated it to `x_valid` (the correct validation input I think) so the example runs 
successfully when copied and produces the residual cross-correlation plots.
