### PR TITLE
Api/uofr fixes

### DIFF
--- a/sysidentpy/model_structure_selection/sobolev_orthogonal_forward_regression.py
+++ b/sysidentpy/model_structure_selection/sobolev_orthogonal_forward_regression.py
@@ -4,7 +4,7 @@
 #           Wilson Rocha Lacerda Junior <wilsonrljr@outlook.com>
 # License: BSD 3 clause
 
-from typing import Union, Tuple, Optional
+from typing import Union, Tuple, Optional, Callable
 
 import numpy as np
 
@@ -105,6 +105,18 @@ class UOFR(OFRBase):
         fitting. If the input is a noisy signal, the ridge parameter is likely to be
         set close to the noise level, at least as a starting point.
         Entered through the self data structure.
+    sobolev_order : int, default=2
+        Number of weak derivatives included in the Ultra Least Squares (ULS)
+        augmentation (m in the manuscript). Set to zero to disable augmentation.
+    test_support : int, default=11
+        Number of discrete samples used to represent the modulating function and
+        its derivatives. An odd number is recommended so the kernel is centered.
+    modulating_function : {"bspline", "gaussian"} or callable, default="bspline"
+        Choice of test function used to smooth the signals before differentiating.
+        A custom callable must accept the sampling grid and the derivative order
+        and return the corresponding discrete kernel.
+    gaussian_sigma : float, default=1.0
+        Standard deviation used when `modulating_function="gaussian"`.
 
     Examples
     --------
@@ -169,6 +181,12 @@ class UOFR(OFRBase):
         eps: np.float64 = np.finfo(np.float64).eps,
         alpha: float = 0,
         err_tol: Optional[float] = None,
+        sobolev_order: int = 2,
+        test_support: int = 11,
+        modulating_function: Union[
+            str, Callable[[np.ndarray, int], np.ndarray]
+        ] = "bspline",
+        gaussian_sigma: float = 1.0,
     ):
         self.order_selection = order_selection
         self.ylag = ylag
@@ -189,6 +207,10 @@ class UOFR(OFRBase):
             self.alpha = alpha
 
         self.err_tol = err_tol
+        self.sobolev_order = sobolev_order
+        self.test_support = test_support
+        self.modulating_function = modulating_function
+        self.gaussian_sigma = gaussian_sigma
         self._validate_params()
         self.n_inputs = None
         self.regressor_code = None
@@ -197,11 +219,106 @@ class UOFR(OFRBase):
         self.final_model = None
         self.theta = None
         self.pivv = None
+        self._validate_uofr_params()
+
+    def _validate_uofr_params(self) -> None:
+        if not isinstance(self.sobolev_order, int) or self.sobolev_order < 0:
+            raise ValueError(
+                f"sobolev_order must be an integer >= 0. Got {self.sobolev_order}"
+            )
+
+        if not isinstance(self.test_support, int) or self.test_support < 3:
+            raise ValueError(
+                f"test_support must be an integer >= 3. Got {self.test_support}"
+            )
+
+        if self.test_support % 2 == 0:
+            raise ValueError("test_support must be odd to center the test function.")
+
+        if isinstance(self.modulating_function, str):
+            allowed = {"bspline", "gaussian"}
+            if self.modulating_function not in allowed:
+                raise ValueError(
+                    "modulating_function must be 'bspline', 'gaussian', or a callable."
+                )
+        elif not callable(self.modulating_function):
+            raise TypeError(
+                "modulating_function must be a callable or one of the supported strings."
+            )
+
+        if (
+            not isinstance(self.gaussian_sigma, (int, float))
+            or self.gaussian_sigma <= 0
+        ):
+            raise ValueError(
+                f"gaussian_sigma must be a positive float. Got {self.gaussian_sigma}"
+            )
+
+    def _test_function_grid(self) -> np.ndarray:
+        if isinstance(self.modulating_function, str):
+            if self.modulating_function == "bspline":
+                span = 2.0
+            else:
+                span = 3.0 * float(self.gaussian_sigma)
+        else:
+            span = 1.0
+        return np.linspace(-span, span, self.test_support)
+
+    def _evaluate_test_function(self, t: np.ndarray, order: int) -> np.ndarray:
+        if isinstance(self.modulating_function, str):
+            if self.modulating_function == "bspline":
+                return self._bspline_kernel(t, order)
+            return self.gaussian_test_function(t, order)
+        return self.modulating_function(t, order)
+
+    def _bspline_kernel(self, t: np.ndarray, order: int) -> np.ndarray:
+        """Evaluate cubic B-spline and derivatives up to order 3."""
+        abs_t = np.abs(t)
+        sign_t = np.sign(t)
+        if order == 0:
+            result = np.zeros_like(t)
+            mask_inner = abs_t < 1
+            result[mask_inner] = (
+                (2.0 / 3.0) - abs_t[mask_inner] ** 2 + 0.5 * abs_t[mask_inner] ** 3
+            )
+            mask_outer = (abs_t >= 1) & (abs_t < 2)
+            result[mask_outer] = ((2 - abs_t[mask_outer]) ** 3) / 6.0
+            return result
+
+        if order == 1:
+            derivative = np.zeros_like(t)
+            mask_inner = abs_t < 1
+            derivative[mask_inner] = (
+                -2 * abs_t[mask_inner] + 1.5 * abs_t[mask_inner] ** 2
+            )
+            mask_outer = (abs_t >= 1) & (abs_t < 2)
+            derivative[mask_outer] = -0.5 * (2 - abs_t[mask_outer]) ** 2
+            return derivative * sign_t
+
+        if order == 2:
+            second_derivative = np.zeros_like(t)
+            mask_inner = abs_t < 1
+            second_derivative[mask_inner] = -2 + 3 * abs_t[mask_inner]
+            mask_outer = (abs_t >= 1) & (abs_t < 2)
+            second_derivative[mask_outer] = 2 - abs_t[mask_outer]
+            return second_derivative
+
+        if order == 3:
+            third_derivative = np.zeros_like(t)
+            mask_inner = abs_t < 1
+            third_derivative[mask_inner] = 3
+            mask_outer = (abs_t >= 1) & (abs_t < 2)
+            third_derivative[mask_outer] = -1
+            return third_derivative * sign_t
+
+        return np.zeros_like(t)
 
     def gaussian_test_function(self, t: np.ndarray, order: int) -> np.ndarray:
         """Generate Gaussian-like test function derivatives."""
-        sigma = 1.0  # Adjust based on signal characteristics
+        sigma = float(self.gaussian_sigma)
         gaussian = np.exp(-(t**2) / (2 * sigma**2))
+        if order == 0:
+            return gaussian
         derivative = np.gradient(gaussian, t)
         for _ in range(order - 1):
             derivative = np.gradient(derivative, t)
@@ -215,30 +332,36 @@ class UOFR(OFRBase):
     def compute_modulated_signal(
         self, signal: np.ndarray, phi_bar_j: np.ndarray
     ) -> np.ndarray:
-        modulated = np.convolve(signal.flatten(), phi_bar_j, mode="valid")
-        return modulated  # Length = len(signal) - len(phi_bar_j) + 1
+        flattened_signal = signal.reshape(-1)
+        modulated = np.convolve(flattened_signal, phi_bar_j, mode="same")
+        return modulated
 
     def augment_uls_terms(
-        self, y: np.ndarray, psi: np.ndarray, m: int = 2, test_support: int = 5
+        self, y: np.ndarray, psi: np.ndarray, m: Optional[int] = None
     ) -> Tuple[np.ndarray, np.ndarray]:
-        """Augment signals for ULS with matching row counts."""
-        modulated_length = len(y) - test_support + 1
-        num_terms = psi.shape[1]
-        t = np.linspace(-3, 3, test_support)
+        """Augment the regression problem following Eq. (22)-(28)."""
+        y = y.reshape(-1, 1)
+        if m is None:
+            m = self.sobolev_order
+        if m == 0:
+            return y, psi
 
-        # Initialize y_augmented and psi_augmented with original truncated signals
-        y_augmented = y[:modulated_length].reshape(-1, 1)
-        psi_augmented = psi[:modulated_length, :]
+        base_length = y.shape[0]
+        num_terms = psi.shape[1]
+        y_augmented = y.copy()
+        psi_augmented = psi.copy()
+        t = self._test_function_grid()
 
         for j in range(1, m + 1):
-            phi_j = self.gaussian_test_function(t, order=j)
+            phi_j = self._evaluate_test_function(t, order=j)
             phi_bar_j = self.normalize_test_function(phi_j)
-            y_j = self.compute_modulated_signal(y, phi_bar_j).reshape(-1, 1)
+            y_j = self.compute_modulated_signal(y[:, 0], phi_bar_j).reshape(-1, 1)
             y_augmented = np.vstack([y_augmented, y_j])
-            modulated_terms = np.zeros((modulated_length, num_terms))
+            modulated_terms = np.zeros((base_length, num_terms))
             for term in range(num_terms):
-                x_j = self.compute_modulated_signal(psi[:, term], phi_bar_j)
-                modulated_terms[:, term] = x_j
+                modulated_terms[:, term] = self.compute_modulated_signal(
+                    psi[:, term], phi_bar_j
+                )
 
             psi_augmented = np.vstack([psi_augmented, modulated_terms])
 
@@ -249,12 +372,12 @@ class UOFR(OFRBase):
         psi: np.ndarray,
         y: np.ndarray,
         process_term_number: int,
-        m: int = 2,
-        test_support: int = 5,
-    ) -> Tuple[np.ndarray, np.ndarray, np.ndarray]:
+    ) -> Tuple[np.ndarray, np.ndarray, np.ndarray, np.ndarray]:
         """Define Ultra Orthogonal Least Squares."""
-        y = y[self.max_lag :, 0].reshape(-1, 1)
-        y_augmented, psi_augmented = self.augment_uls_terms(y, psi, m, test_support)
+        y_target = y[self.max_lag :, 0].reshape(-1, 1)
+        y_augmented, psi_augmented = self.augment_uls_terms(
+            y_target, psi, self.sobolev_order
+        )
         y_augmented = y_augmented.reshape(-1, 1)
         # Compute ERR on the augmented ULS matrix
         squared_y = np.dot(y_augmented.T, y_augmented)
@@ -296,12 +419,12 @@ class UOFR(OFRBase):
             psi_working[step_idx:, step_idx:] = np.copy(row_result)
 
         tmp_piv = piv[0:process_term_number]
-        psi_orthogonal = psi[:, tmp_piv]
-        return err, tmp_piv, psi_orthogonal
+        psi_orthogonal = psi_augmented[:, tmp_piv]
+        return err, tmp_piv, psi_orthogonal, y_augmented
 
     def run_mss_algorithm(
         self, psi: np.ndarray, y: np.ndarray, process_term_number: int
-    ) -> Tuple[np.ndarray, np.ndarray, np.ndarray]:
+    ) -> Tuple[np.ndarray, np.ndarray, np.ndarray, np.ndarray]:
         return self.sobolev_error_reduction_ratio(psi, y, process_term_number)
 
     def fit(self, *, X: Optional[np.ndarray] = None, y: np.ndarray):

--- a/sysidentpy/model_structure_selection/sobolev_orthogonal_forward_regression.py
+++ b/sysidentpy/model_structure_selection/sobolev_orthogonal_forward_regression.py
@@ -1,4 +1,44 @@
-"""Build NARMAX Models using UOFR algorithm."""
+"""Build NARMAX Models using UOFR algorithm.
+
+Implementation Notes
+--------------------
+This module implements the Ultra-Orthogonal Forward Regression (UOFR) algorithm
+as described in [1]. Some implementation decisions extend or interpret the
+original paper to handle practical edge cases:
+
+1. **Normalization of antisymmetric kernels (Eq. 20-21)**:
+   The paper requires normalized test functions to satisfy both unit L2 norm
+   (Eq. 20) and unit integral (Eq. 21). However, odd-order derivatives of
+   symmetric functions (e.g., 1st and 3rd derivatives of B-splines) are
+   antisymmetric and have zero integral by definition. This implementation
+   applies L2 normalization and returns a separate area correction factor
+   for cases where the integral is non-zero.
+
+2. **Length weighting for modulated signals**:
+   The convolution with 'valid' mode reduces the number of samples in
+   modulated signals. To prevent derivative terms from being underweighted
+   in the ULS criterion (Eq. 24), we apply a scaling factor of
+   sqrt(N_original / N_modulated). This is not explicitly mentioned in the
+   paper but ensures balanced contribution across all Sobolev orders.
+
+3. **Convolution vs. correlation (Eq. 25)**:
+   The paper defines modulation as a sum that corresponds to cross-correlation.
+   We implement this using np.convolve with a flipped kernel, which is
+   mathematically equivalent to the correlation defined in Eq. 25.
+
+4. **B-spline derivatives**:
+   We use closed-form expressions for the cubic B-spline and its derivatives
+   up to order 3, consistent with Appendix A of the paper. The cubic B-spline
+   has continuous derivatives only up to order 2, so the 3rd derivative is
+   piecewise constant.
+
+References
+----------
+.. [1] Guo, Y., Guo, L.Z., Billings, S.A., Wei, H.L. (2015).
+   "Ultra-Orthogonal Forward Regression Algorithms for the Identification
+   of Non-Linear Dynamic Systems". Neurocomputing.
+   https://eprints.whiterose.ac.uk/107310/1/UOFR%20Algorithms%20R1.pdf
+"""
 
 # Authors:
 #           Wilson Rocha Lacerda Junior <wilsonrljr@outlook.com>
@@ -69,10 +109,27 @@ class UOFR(OFRBase):
     are the maximum lags for the system output and input respectively;
     $x_k \in \mathbb{R}^{n_x}$ is the system input and $y_k \in \mathbb{R}^{n_y}$
     is the system output at discrete time $k \in \mathbb{N}^n$;
-    $e_k \in \mathbb{R}^{n_e}4 stands for uncertainties and possible noise
+    $e_k \in \mathbb{R}^{n_e}$ stands for uncertainties and possible noise
     at discrete time $k$. In this case, $\mathcal{F}$ is some nonlinear function
     of the input and output regressors and $d$ is a time delay typically set to
-     $d=1$.
+    $d=1$.
+
+    The UOFR algorithm extends the classic OFR by using the Ultra-Least Squares
+    (ULS) criterion, which measures model fitness in the Sobolev space H^m
+    instead of the standard L^2 space. This criterion considers not only the
+    residuals but also the weak derivatives of the signals, providing a stricter
+    measure of model quality.
+
+    The ULS criterion is defined as (Eq. 24 in [1]):
+
+    $$
+        J_{ULS} = \left\| y - \sum_{i=1}^{k} \theta_i x_i \right\|_2^2 +
+        \sum_{l=1}^{m} \left\| \overline{y}^l - \sum_{i=1}^{k} \theta_i
+        \overline{x}_i^l \right\|_2^2
+    $$
+
+    where $\overline{y}^l$ and $\overline{x}_i^l$ are the signals modulated
+    by the normalized l-th derivative of the test function.
 
     Parameters
     ----------
@@ -107,39 +164,68 @@ class UOFR(OFRBase):
         Entered through the self data structure.
     sobolev_order : int, default=2
         Number of weak derivatives included in the Ultra Least Squares (ULS)
-        augmentation (m in the manuscript). Set to zero to disable augmentation.
+        augmentation (m in the manuscript, Eq. 22). Set to zero to disable
+        augmentation and use standard OFR. The paper recommends m=2 for most
+        applications (using 1st and 2nd derivatives).
     test_support : int, default=11
         Number of discrete samples used to represent the modulating function and
-        its derivatives. An odd number is recommended so the kernel is centered.
+        its derivatives (n_0 in Eq. 25). An odd number is recommended so the
+        kernel is centered. Larger values provide smoother modulation but reduce
+        the number of valid samples after convolution.
     modulating_function : {"bspline", "gaussian"} or callable, default="bspline"
         Choice of test function used to smooth the signals before differentiating.
-        A custom callable must accept the sampling grid and the derivative order
-        and return the corresponding discrete kernel.
+        The paper uses cubic B-spline (Appendix A) as it has finite support and
+        continuous derivatives up to order 2. Options:
+
+        - "bspline": Cubic B-spline as defined in Appendix A of [1].
+        - "gaussian": Gaussian-like function with configurable sigma.
+        - callable: Custom function with signature f(t, order) -> np.ndarray,
+          where t is the grid and order is the derivative order.
+
     gaussian_sigma : float, default=1.0
         Standard deviation used when `modulating_function="gaussian"`.
+        Only used if modulating_function is "gaussian".
+
+    Notes
+    -----
+    **Implementation decisions not explicitly covered in the paper:**
+
+    1. **Antisymmetric kernel normalization**: Odd-order derivatives of symmetric
+       test functions have zero integral, making Eq. 21 impossible to satisfy
+       directly. We handle this by applying L2 normalization and tracking area
+       correction separately.
+
+    2. **Sample count balancing**: Convolution reduces sample count. We scale
+       modulated signals by sqrt(N_original/N_modulated) to maintain balanced
+       contribution to the ULS criterion.
+
+    3. **Parameter estimation**: The paper states parameters should be estimated
+       using least squares on the original problem (Step 8). This implementation
+       uses the configured estimator on the selected model terms.
 
     Examples
     --------
     >>> import numpy as np
     >>> import matplotlib.pyplot as plt
-    >>> from sysidentpy.model_structure_selection import FROLS
+    >>> from sysidentpy.model_structure_selection import UOFR
     >>> from sysidentpy.basis_function import Polynomial
     >>> from sysidentpy.utils.display_results import results
     >>> from sysidentpy.metrics import root_relative_squared_error
-    >>> from sysidentpy.utils.generate_data import get_miso_data, get_siso_data
+    >>> from sysidentpy.utils.generate_data import get_siso_data
     >>> x_train, x_valid, y_train, y_valid = get_siso_data(n=1000,
     ...                                                    colored_noise=True,
     ...                                                    sigma=0.2,
     ...                                                    train_percentage=90)
     >>> basis_function = Polynomial(degree=2)
     >>> model = UOFR(basis_function=basis_function,
-    ...               order_selection=True,
-    ...               n_info_values=10,
-    ...               extended_least_squares=False,
-    ...               ylag=2,
-    ...               xlag=2,
-    ...               info_criteria='aic',
-    ...               )
+    ...              order_selection=True,
+    ...              n_info_values=10,
+    ...              extended_least_squares=False,
+    ...              ylag=2,
+    ...              xlag=2,
+    ...              info_criteria='aic',
+    ...              sobolev_order=2,  # Use 1st and 2nd derivatives
+    ...              )
     >>> model.fit(x_train, y_train)
     >>> yhat = model.predict(x_valid, y_valid)
     >>> rrse = root_relative_squared_error(y_valid, yhat)
@@ -159,8 +245,9 @@ class UOFR(OFRBase):
 
     References
     ----------
-    - Manuscript: Ultra-Orthogonal Forward Regression Algorithms for the
-        Identification of Non-Linear Dynamic Systems
+    .. [1] Guo, Y., Guo, L.Z., Billings, S.A., Wei, H.L. (2015).
+       "Ultra-Orthogonal Forward Regression Algorithms for the Identification
+       of Non-Linear Dynamic Systems". Neurocomputing.
        https://eprints.whiterose.ac.uk/107310/1/UOFR%20Algorithms%20R1.pdf
 
     """
@@ -222,6 +309,15 @@ class UOFR(OFRBase):
         self._validate_uofr_params()
 
     def _validate_uofr_params(self) -> None:
+        """Validate UOFR-specific parameters.
+
+        Raises
+        ------
+        ValueError
+            If any UOFR parameter is invalid.
+        TypeError
+            If modulating_function is neither a string nor callable.
+        """
         if not isinstance(self.sobolev_order, int) or self.sobolev_order < 0:
             raise ValueError(
                 f"sobolev_order must be an integer >= 0. Got {self.sobolev_order}"
@@ -241,6 +337,11 @@ class UOFR(OFRBase):
                 raise ValueError(
                     "modulating_function must be 'bspline', 'gaussian', or a callable."
                 )
+            if self.modulating_function == "bspline" and self.sobolev_order > 3:
+                raise ValueError(
+                    "B-spline modulating function currently supports derivatives up to order 3. "
+                    "Use a custom callable if higher Sobolev orders are required."
+                )
         elif not callable(self.modulating_function):
             raise TypeError(
                 "modulating_function must be a callable or one of the supported strings."
@@ -255,16 +356,54 @@ class UOFR(OFRBase):
             )
 
     def _test_function_grid(self) -> np.ndarray:
+        """Generate the discrete grid for evaluating the test function.
+
+        The grid is centered at zero and spans the support of the test function.
+        For B-splines, the support is [-2, 2] (cubic B-spline, Appendix A).
+        For Gaussian, the support is [-3*sigma, 3*sigma].
+
+        Returns
+        -------
+        np.ndarray
+            1D array of grid points with length equal to test_support.
+
+        Notes
+        -----
+        The paper (Appendix A) defines the B-spline support implicitly through
+        the knot sequence. Our implementation uses a centered cubic B-spline
+        with support on [-2, 2].
+        """
         if isinstance(self.modulating_function, str):
             if self.modulating_function == "bspline":
+                # Cubic B-spline has support [-2, 2] (Appendix A)
                 span = 2.0
             else:
                 span = 3.0 * float(self.gaussian_sigma)
         else:
+            # Default span for custom functions
             span = 1.0
         return np.linspace(-span, span, self.test_support)
 
     def _evaluate_test_function(self, t: np.ndarray, order: int) -> np.ndarray:
+        """Evaluate the test function or its derivatives at given points.
+
+        Parameters
+        ----------
+        t : np.ndarray
+            Grid points where to evaluate the function.
+        order : int
+            Derivative order (0 = function itself, 1 = first derivative, etc.)
+
+        Returns
+        -------
+        np.ndarray
+            Function values at the grid points.
+
+        Notes
+        -----
+        This corresponds to computing phi^(l)(t) as described in Step 2 of the
+        UOFR algorithm in Section 4.
+        """
         if isinstance(self.modulating_function, str):
             if self.modulating_function == "bspline":
                 return self._bspline_kernel(t, order)
@@ -272,10 +411,49 @@ class UOFR(OFRBase):
         return self.modulating_function(t, order)
 
     def _bspline_kernel(self, t: np.ndarray, order: int) -> np.ndarray:
-        """Evaluate cubic B-spline and derivatives up to order 3."""
+        """Evaluate cubic B-spline and derivatives up to order 3.
+
+        Implements the cubic B-spline basis function as defined in Appendix A
+        (Eq. 39-42) of the paper. The B-spline is centered at t=0 with support
+        on [-2, 2].
+
+        The cubic B-spline is defined as:
+            B_3(t) = {
+                (2/3) - |t|^2 + (1/2)|t|^3,  if |t| < 1
+                (1/6)(2 - |t|)^3,             if 1 <= |t| < 2
+                0,                            otherwise
+            }
+
+        Parameters
+        ----------
+        t : np.ndarray
+            Grid points where to evaluate the function.
+        order : int
+            Derivative order (0, 1, 2, or 3).
+
+        Returns
+        -------
+        np.ndarray
+            B-spline or derivative values at the grid points.
+
+        Notes
+        -----
+        - Order 0: The B-spline itself (symmetric, positive).
+        - Order 1: First derivative (antisymmetric, zero integral).
+        - Order 2: Second derivative (symmetric).
+        - Order 3: Third derivative (piecewise constant, antisymmetric).
+
+        The derivatives are computed analytically following Eq. 41-42, not
+        numerically, to avoid discretization errors.
+
+        The third derivative is included for completeness but note that the
+        cubic B-spline only has continuous derivatives up to order 2.
+        """
         abs_t = np.abs(t)
         sign_t = np.sign(t)
+
         if order == 0:
+            # Cubic B-spline: B_3(t) - Eq. 39 in Appendix A
             result = np.zeros_like(t)
             mask_inner = abs_t < 1
             result[mask_inner] = (
@@ -286,6 +464,9 @@ class UOFR(OFRBase):
             return result
 
         if order == 1:
+            # First derivative: d/dt B_3(t) - Eq. 41 in Appendix A
+            # For |t| < 1: d/dt[(2/3) - t^2 + (1/2)|t|^3] = -2t + (3/2)t|t|
+            # For 1 <= |t| < 2: d/dt[(1/6)(2-|t|)^3] = -(1/2)(2-|t|)^2 * sign(t)
             derivative = np.zeros_like(t)
             mask_inner = abs_t < 1
             derivative[mask_inner] = (
@@ -293,9 +474,14 @@ class UOFR(OFRBase):
             )
             mask_outer = (abs_t >= 1) & (abs_t < 2)
             derivative[mask_outer] = -0.5 * (2 - abs_t[mask_outer]) ** 2
+            # Multiply by sign(t) because d|t|/dt = sign(t)
             return derivative * sign_t
 
         if order == 2:
+            # Second derivative: d^2/dt^2 B_3(t) - Eq. 42 in Appendix A
+            # For |t| < 1: -2 + 3|t|
+            # For 1 <= |t| < 2: (2 - |t|)
+            # Note: This is symmetric, so no sign multiplication needed
             second_derivative = np.zeros_like(t)
             mask_inner = abs_t < 1
             second_derivative[mask_inner] = -2 + 3 * abs_t[mask_inner]
@@ -304,6 +490,10 @@ class UOFR(OFRBase):
             return second_derivative
 
         if order == 3:
+            # Third derivative: d^3/dt^3 B_3(t)
+            # Piecewise constant (B-spline has C^2 continuity)
+            # For |t| < 1: 3 * sign(t)
+            # For 1 <= |t| < 2: -sign(t)
             third_derivative = np.zeros_like(t)
             mask_inner = abs_t < 1
             third_derivative[mask_inner] = 3
@@ -311,39 +501,223 @@ class UOFR(OFRBase):
             third_derivative[mask_outer] = -1
             return third_derivative * sign_t
 
+        # For orders > 3, return zeros (B-spline derivatives vanish)
         return np.zeros_like(t)
 
     def gaussian_test_function(self, t: np.ndarray, order: int) -> np.ndarray:
-        """Generate Gaussian-like test function derivatives."""
+        """Generate Gaussian-like test function and its derivatives.
+
+        Provides an alternative to B-splines with infinite smoothness,
+        though truncated to finite support for practical computation.
+
+        Parameters
+        ----------
+        t : np.ndarray
+            Grid points where to evaluate the function.
+        order : int
+            Derivative order (0 = function itself).
+
+        Returns
+        -------
+        np.ndarray
+            Gaussian or derivative values at the grid points.
+
+        Notes
+        -----
+        Unlike B-splines, the Gaussian has infinite derivatives. However,
+        derivatives are computed numerically using np.gradient, which may
+        introduce discretization errors for high orders. For high-order
+        Sobolev spaces, consider using analytic Hermite polynomial
+        expressions or a custom callable.
+        """
         sigma = float(self.gaussian_sigma)
         gaussian = np.exp(-(t**2) / (2 * sigma**2))
+
+        # Truncate to finite support
+        span = np.max(np.abs(t))
+        gaussian[np.abs(t) >= span] = 0.0
+
         if order == 0:
             return gaussian
-        derivative = np.gradient(gaussian, t)
-        for _ in range(order - 1):
+
+        derivative = gaussian.copy()
+        for _ in range(order):
             derivative = np.gradient(derivative, t)
+            derivative[np.abs(t) >= span] = 0.0
+
         return derivative
 
-    def normalize_test_function(self, phi_j: np.ndarray) -> np.ndarray:
-        """Normalize derivatives."""
+    def normalize_test_function(self, phi_j: np.ndarray) -> Tuple[np.ndarray, float]:
+        """Normalize test function derivative following Eq. 20-21.
+
+        The paper requires (Eq. 20):
+            phi_bar^l = phi^(l) / ||phi^(l)||_2
+
+        And (Eq. 21):
+            integral(phi_bar^l) = 1
+
+        However, for antisymmetric kernels (odd-order derivatives of symmetric
+        functions), the integral is identically zero. This implementation
+        returns the L2-normalized kernel and a separate area correction factor.
+
+        Parameters
+        ----------
+        phi_j : np.ndarray
+            The test function derivative to normalize.
+
+        Returns
+        -------
+        kernel : np.ndarray
+            L2-normalized kernel (satisfies Eq. 20).
+        area_correction : float
+            Factor to scale signals so effective integration equals 1.
+            For antisymmetric kernels, returns 1.0 (no correction possible).
+
+        Raises
+        ------
+        ValueError
+            If the kernel has zero energy (all zeros).
+
+        Notes
+        -----
+        **Implementation decision**: The paper's Eq. 21 cannot be satisfied
+        for antisymmetric kernels. We interpret this as follows:
+
+        - Apply L2 normalization (Eq. 20) to ensure balanced energy contribution.
+        - For symmetric kernels with non-zero integral, compute area correction.
+        - For antisymmetric kernels, use area_correction=1.0 and rely on the
+          L2 normalization to balance the criterion.
+
+        This interpretation ensures that each derivative order contributes
+        proportionally to the ULS criterion without amplifying noise.
+        """
         norm = np.linalg.norm(phi_j, ord=2)
-        return phi_j / norm if norm != 0 else phi_j
+        if norm == 0:
+            raise ValueError("Cannot normalize a zero-energy modulating function.")
+
+        kernel = phi_j / norm
+
+        integral = kernel.sum()
+        if np.isclose(integral, 0.0, atol=self.eps):
+            # Antisymmetric kernel: integral is zero by symmetry
+            # No area correction possible; rely on L2 normalization only
+            area_correction = 1.0
+        else:
+            # Symmetric kernel: correct to unit integral
+            area_correction = 1.0 / float(integral)
+
+        return kernel, area_correction
 
     def compute_modulated_signal(
         self, signal: np.ndarray, phi_bar_j: np.ndarray
     ) -> np.ndarray:
-        flattened_signal = signal.reshape(-1)
-        modulated = np.convolve(flattened_signal, phi_bar_j, mode="same")
+        """Apply discrete convolution matching Eq. 25 of the paper.
+
+        Computes the modulated signal:
+            y_bar^l(k) = sum_{n=k}^{k+n_0} y(n) * phi_bar^l(n-k)
+
+        This is equivalent to cross-correlation, implemented via convolution
+        with a flipped kernel.
+
+        Parameters
+        ----------
+        signal : np.ndarray
+            The signal to modulate (y or x_i).
+        phi_bar_j : np.ndarray
+            The normalized modulating kernel.
+
+        Returns
+        -------
+        np.ndarray
+            Modulated signal with length N - n_0, where N is the original
+            signal length and n_0 is the kernel support (test_support - 1).
+
+        Raises
+        ------
+        ValueError
+            If the kernel is empty or larger than the signal.
+
+        Notes
+        -----
+        **Implementation decision**: We use np.convolve with mode='valid' and
+        a flipped kernel. This is mathematically equivalent to the summation
+        in Eq. 25:
+
+            np.convolve(signal, kernel[::-1], 'valid')[k] =
+            sum_{n=0}^{n_0} signal[k+n] * kernel[n]
+
+        The 'valid' mode ensures we only compute output where the full kernel
+        overlaps with the signal, avoiding boundary effects.
+        """
+        flattened_signal = np.asarray(signal, dtype=np.float64).reshape(-1)
+        kernel = np.asarray(phi_bar_j, dtype=np.float64).reshape(-1)
+
+        kernel_size = kernel.size
+        if kernel_size == 0:
+            raise ValueError("modulating kernel cannot be empty")
+        if flattened_signal.size < kernel_size:
+            raise ValueError(
+                "test_support is too large for the available samples; "
+                "decrease test_support or provide longer signals."
+            )
+
+        # Flip kernel to convert convolution to correlation (matching Eq. 25)
+        reversed_kernel = kernel[::-1]
+        modulated = np.convolve(flattened_signal, reversed_kernel, mode="valid")
+
         return modulated
 
     def augment_uls_terms(
         self, y: np.ndarray, psi: np.ndarray, m: Optional[int] = None
     ) -> Tuple[np.ndarray, np.ndarray]:
-        """Augment the regression problem following Eq. (22)-(28)."""
+        """Augment the regression problem to form the ULS problem (Eq. 22-28).
+
+        Constructs the augmented matrices Y_ULS and Phi_ULS by stacking the
+        original signals with their modulated versions for each derivative order.
+
+        Parameters
+        ----------
+        y : np.ndarray
+            Output signal vector of shape (N,) or (N, 1).
+        psi : np.ndarray
+            Regressor matrix of shape (N, num_terms).
+        m : int, optional
+            Sobolev order (number of derivative levels). Defaults to
+            self.sobolev_order.
+
+        Returns
+        -------
+        y_augmented : np.ndarray
+            Augmented output vector Y_ULS as in Eq. 27.
+            Shape: (N + m*(N-n_0), 1)
+        psi_augmented : np.ndarray
+            Augmented regressor matrix Phi_ULS as in Eq. 28.
+            Shape: (N + m*(N-n_0), num_terms)
+
+        Notes
+        -----
+        **Implementation decisions**:
+
+        1. **Length weighting**: The modulated signals have fewer samples
+           (N - n_0) due to 'valid' convolution. To ensure balanced contribution
+           to the ULS criterion, we scale by sqrt(N_original / N_modulated).
+           This is not explicitly mentioned in the paper but prevents derivative
+           terms from being underweighted.
+
+        2. **Area correction**: Applied after L2 normalization to approximate
+           the unit integral requirement (Eq. 21) for symmetric kernels.
+
+        The augmented system has the form:
+            [y; y_bar^1; ...; y_bar^m] = [psi; psi_bar^1; ...; psi_bar^m] * theta
+
+        where the semicolon denotes vertical stacking.
+        """
         y = y.reshape(-1, 1)
         if m is None:
             m = self.sobolev_order
+
         if m == 0:
+            # No augmentation: standard least squares
             return y, psi
 
         base_length = y.shape[0]
@@ -354,15 +728,29 @@ class UOFR(OFRBase):
 
         for j in range(1, m + 1):
             phi_j = self._evaluate_test_function(t, order=j)
-            phi_bar_j = self.normalize_test_function(phi_j)
+            phi_bar_j, area_correction = self.normalize_test_function(phi_j)
             y_j = self.compute_modulated_signal(y[:, 0], phi_bar_j).reshape(-1, 1)
+            modulated_length = y_j.shape[0]
+
+            # **Implementation decision**: Length weighting
+            # The paper's Eq. 24 sums terms directly, but modulated signals
+            # have fewer samples. We scale to balance contribution:
+            #   weight = sqrt(N / N_modulated)
+            # This ensures that ||y_bar^l||^2 in the criterion is comparable
+            # to ||y||^2 in terms of sample count influence.
+            length_weight = np.sqrt(base_length / modulated_length)
+            modulation_scale = area_correction * length_weight
+            y_j *= modulation_scale
+
             y_augmented = np.vstack([y_augmented, y_j])
-            modulated_terms = np.zeros((base_length, num_terms))
+
+            modulated_terms = np.zeros((modulated_length, num_terms))
             for term in range(num_terms):
                 modulated_terms[:, term] = self.compute_modulated_signal(
                     psi[:, term], phi_bar_j
                 )
 
+            modulated_terms *= modulation_scale
             psi_augmented = np.vstack([psi_augmented, modulated_terms])
 
         return y_augmented, psi_augmented
@@ -373,13 +761,54 @@ class UOFR(OFRBase):
         y: np.ndarray,
         process_term_number: int,
     ) -> Tuple[np.ndarray, np.ndarray, np.ndarray, np.ndarray]:
-        """Define Ultra Orthogonal Least Squares."""
+        """Compute ERR on the ULS-augmented regression problem.
+
+        Implements Steps 5-7 of the UOFR algorithm: compute ERR significance
+        for each term using the augmented ULS matrices and select terms in
+        a forward greedy manner.
+
+        The ERR is computed as (Eq. 33 in the paper):
+            ERR(phi_k) = <w_k, y>^2 / (<w_k, w_k> * <y, y>)
+
+        where w_k is the orthogonalized regressor.
+
+        Parameters
+        ----------
+        psi : np.ndarray
+            Original regressor matrix of shape (N, num_terms).
+        y : np.ndarray
+            Output signal of shape (N, 1).
+        process_term_number : int
+            Maximum number of terms to select.
+
+        Returns
+        -------
+        err : np.ndarray
+            ERR values for each selected term (Eq. 33 computed on ULS problem).
+        piv : np.ndarray
+            Indices of selected terms in order of selection.
+        psi_orthogonal : np.ndarray
+            Augmented regressor matrix with selected columns.
+        y_augmented : np.ndarray
+            Augmented output vector.
+
+        Notes
+        -----
+        The ERR is computed using the augmented matrices (Y_ULS, Phi_ULS),
+        which means term significance is evaluated considering both the
+        original fit and the derivative fits. This is the key difference
+        from standard OFR: terms that appear significant under L2 may be
+        less significant under the Sobolev norm, and vice versa.
+
+        The orthogonalization uses Householder reflections for numerical
+        stability, as mentioned in the paper (any orthogonalization method
+        is valid, but Householder is preferred for large problems).
+        """
         y_target = y[self.max_lag :, 0].reshape(-1, 1)
         y_augmented, psi_augmented = self.augment_uls_terms(
             y_target, psi, self.sobolev_order
         )
         y_augmented = y_augmented.reshape(-1, 1)
-        # Compute ERR on the augmented ULS matrix
         squared_y = np.dot(y_augmented.T, y_augmented)
         squared_y = float(np.maximum(squared_y, np.finfo(np.float64).eps))
         psi_working = psi_augmented.copy()
@@ -401,6 +830,7 @@ class UOFR(OFRBase):
 
             max_err_idx = np.argmax(candidate_err[step_idx:]) + step_idx
             err[step_idx] = candidate_err[max_err_idx]
+
             if step_idx == process_term_number:
                 break
 
@@ -413,6 +843,7 @@ class UOFR(OFRBase):
                 :, [step_idx, max_err_idx]
             ]
             piv[[max_err_idx, step_idx]] = piv[[step_idx, max_err_idx]]
+
             reflector = house(psi_working[step_idx:, step_idx])
             row_result = rowhouse(psi_working[step_idx:, step_idx:], reflector)
             y_working[step_idx:] = rowhouse(y_working[step_idx:], reflector)
@@ -420,11 +851,32 @@ class UOFR(OFRBase):
 
         tmp_piv = piv[0:process_term_number]
         psi_orthogonal = psi_augmented[:, tmp_piv]
+
         return err, tmp_piv, psi_orthogonal, y_augmented
 
     def run_mss_algorithm(
         self, psi: np.ndarray, y: np.ndarray, process_term_number: int
     ) -> Tuple[np.ndarray, np.ndarray, np.ndarray, np.ndarray]:
+        """Run the model structure selection algorithm.
+
+        This method overrides the base class to use the UOFR algorithm
+        instead of standard OFR.
+
+        Parameters
+        ----------
+        psi : np.ndarray
+            Regressor matrix.
+        y : np.ndarray
+            Output signal.
+        process_term_number : int
+            Maximum number of terms to select.
+
+        Returns
+        -------
+        tuple
+            (err, piv, psi_selected, y_target) as returned by
+            sobolev_error_reduction_ratio.
+        """
         return self.sobolev_error_reduction_ratio(psi, y, process_term_number)
 
     def fit(self, *, X: Optional[np.ndarray] = None, y: np.ndarray):
@@ -469,6 +921,24 @@ class UOFR(OFRBase):
         steps_ahead: Optional[int] = None,
         forecast_horizon: Optional[int] = None,
     ) -> np.ndarray:
+        """Predict output using the fitted UOFR model.
+
+        Parameters
+        ----------
+        X : ndarray of floats, optional
+            Input data for prediction.
+        y : ndarray of floats
+            Output data (initial conditions for simulation).
+        steps_ahead : int, optional
+            Number of steps ahead for prediction.
+        forecast_horizon : int, optional
+            Forecast horizon for multi-step prediction.
+
+        Returns
+        -------
+        yhat : np.ndarray
+            Predicted output values.
+        """
         yhat = super().predict(
             X=X, y=y, steps_ahead=steps_ahead, forecast_horizon=forecast_horizon
         )

--- a/sysidentpy/model_structure_selection/tests/test_uofr.py
+++ b/sysidentpy/model_structure_selection/tests/test_uofr.py
@@ -6,6 +6,7 @@ from sysidentpy.basis_function import Polynomial
 from sysidentpy.parameter_estimation.estimators import (
     LeastSquares,
     RecursiveLeastSquares,
+    RidgeRegression,
 )
 from sysidentpy.tests.test_narmax_base import create_test_data
 
@@ -26,7 +27,7 @@ X_test = np.reshape(X_test, (len(X_test), 1))
 def test_error_reduction_ratio():
     # piv = np.array([4, 2, 7, 11, 5])
     model_code = np.array(
-        [[2002, 0], [1002, 0], [2001, 1001], [2002, 1002], [1001, 1001]]
+        [[2002, 0], [1002, 0], [1001, 1001], [2001, 1001], [2002, 1002]]
     )
     basis_function = Polynomial(degree=2)
     x, y, _ = create_test_data()
@@ -176,7 +177,7 @@ def test_information_criteria_bic():
         basis_function=basis_function,
     )
     model.fit(X=x, y=y)
-    info_values = np.array([-1764.885, -2320.101, -2976.391, -4461.908, -72845.768])
+    info_values = np.array([-1959.320155, -2612.875131, -2948.136725, -3300.113919])
     assert_almost_equal(model.info_values[:4], info_values[:4], decimal=3)
 
 
@@ -193,7 +194,7 @@ def test_information_criteria_aicc():
         basis_function=basis_function,
     )
     model.fit(X=x, y=y)
-    info_values = np.array([-1769.787, -2329.901, -2991.084, -4481.490])
+    info_values = np.array([-1964.221892, -2622.674577, -2962.82984, -3319.69665])
     assert_almost_equal(model.info_values[:4], info_values[:4], decimal=3)
 
 
@@ -210,9 +211,7 @@ def test_information_criteria_fpe():
         basis_function=basis_function,
     )
     model.fit(X=x, y=y)
-    info_values = np.array(
-        [-1769.7907932, -2329.9129013, -2991.1078281, -4481.5306067, -72870.296884]
-    )
+    info_values = np.array([-1964.225908, -2622.686632, -2962.853966, -3319.736889])
     assert_almost_equal(model.info_values[:4], info_values[:4], decimal=3)
 
 
@@ -229,5 +228,172 @@ def test_information_criteria_lilc():
         basis_function=basis_function,
     )
     model.fit(X=x, y=y)
-    info_values = np.array([-1767.926, -2326.183, -2985.514, -4474.072, -72860.973])
+    info_values = np.array([-1962.361199, -2618.957218, -2957.259855, -3312.278093])
     assert_almost_equal(model.info_values[:4], info_values[:4], decimal=3)
+
+
+def test_ridge_regression_sets_alpha():
+    estimator = RidgeRegression(alpha=0.42)
+    model = UOFR(estimator=estimator, basis_function=Polynomial(degree=1))
+    assert model.alpha == estimator.alpha
+
+
+def test_validate_sobolev_order_non_negative():
+    assert_raises(
+        ValueError, UOFR, sobolev_order=-1, basis_function=Polynomial(degree=1)
+    )
+
+
+def test_validate_test_support_minimum():
+    assert_raises(ValueError, UOFR, test_support=1, basis_function=Polynomial(degree=1))
+
+
+def test_validate_test_support_odd():
+    assert_raises(ValueError, UOFR, test_support=4, basis_function=Polynomial(degree=1))
+
+
+def test_validate_modulating_function_string():
+    assert_raises(
+        ValueError,
+        UOFR,
+        modulating_function="invalid",
+        basis_function=Polynomial(degree=1),
+    )
+
+
+def test_validate_modulating_function_callable_required():
+    assert_raises(
+        TypeError, UOFR, modulating_function=5, basis_function=Polynomial(degree=1)
+    )
+
+
+def test_validate_gaussian_sigma_positive():
+    assert_raises(
+        ValueError,
+        UOFR,
+        modulating_function="gaussian",
+        gaussian_sigma=0,
+        basis_function=Polynomial(degree=1),
+    )
+
+
+def test_test_function_grid_gaussian_span_matches_sigma():
+    model = UOFR(
+        modulating_function="gaussian",
+        gaussian_sigma=2.0,
+        basis_function=Polynomial(degree=1),
+    )
+    grid = model._test_function_grid()
+    assert_almost_equal(grid[0], -6.0)
+    assert_almost_equal(grid[-1], 6.0)
+
+
+def test_test_function_grid_with_callable_uses_unit_span():
+    custom_phi = lambda t, order: np.ones_like(t)
+    model = UOFR(modulating_function=custom_phi, basis_function=Polynomial(degree=1))
+    grid = model._test_function_grid()
+    assert_almost_equal(grid[0], -1.0)
+    assert_almost_equal(grid[-1], 1.0)
+
+
+def test_evaluate_test_function_with_callable_uses_custom_function():
+    custom_phi = lambda t, order: np.full_like(t, fill_value=float(order))
+    model = UOFR(modulating_function=custom_phi, basis_function=Polynomial(degree=1))
+    grid = model._test_function_grid()
+    values = model._evaluate_test_function(grid, 2)
+    assert_array_equal(values, np.full_like(grid, 2.0))
+
+
+def test_evaluate_test_function_returns_gaussian_branch():
+    model = UOFR(
+        modulating_function="gaussian",
+        gaussian_sigma=1.0,
+        basis_function=Polynomial(degree=1),
+    )
+    grid = model._test_function_grid()
+    expected = model.gaussian_test_function(grid, 1)
+    result = model._evaluate_test_function(grid, 1)
+    assert_array_equal(result, expected)
+
+
+def test_bspline_kernel_covers_orders_zero_and_three():
+    model = UOFR(basis_function=Polynomial(degree=1))
+    t = np.array([-1.5, -0.5, 0.0, 0.5, 1.5])
+    order0 = model._bspline_kernel(t, 0)
+    assert_almost_equal(order0[2], 2.0 / 3.0)
+    order3 = model._bspline_kernel(t, 3)
+    assert_almost_equal(order3[1], -3.0)
+    assert_almost_equal(order3[3], 3.0)
+
+
+def test_bspline_kernel_returns_zero_for_higher_orders():
+    model = UOFR(basis_function=Polynomial(degree=1))
+    t = np.linspace(-2, 2, 9)
+    assert_array_equal(model._bspline_kernel(t, 5), np.zeros_like(t))
+
+
+def test_gaussian_test_function_higher_order_uses_gradients():
+    model = UOFR(
+        modulating_function="gaussian",
+        gaussian_sigma=1.5,
+        basis_function=Polynomial(degree=1),
+    )
+    t = np.linspace(-1, 1, 7)
+    second = model.gaussian_test_function(t, 2)
+    assert second.shape == t.shape
+    assert not np.allclose(second, 0)
+
+
+def test_gaussian_test_function_order_zero_returns_gaussian():
+    model = UOFR(
+        modulating_function="gaussian",
+        gaussian_sigma=1.5,
+        basis_function=Polynomial(degree=1),
+    )
+    t = np.linspace(-1, 1, 7)
+    gaussian = np.exp(-(t**2) / (2 * model.gaussian_sigma**2))
+    assert_array_equal(model.gaussian_test_function(t, 0), gaussian)
+
+
+def test_augment_uls_terms_returns_original_when_order_zero():
+    model = UOFR(sobolev_order=0, basis_function=Polynomial(degree=1))
+    y_sample = np.array([[1.0], [2.0], [3.0]])
+    psi_sample = np.ones((3, 2))
+    y_aug, psi_aug = model.augment_uls_terms(y_sample, psi_sample)
+    assert_array_equal(y_aug, y_sample)
+    assert_array_equal(psi_aug, psi_sample)
+
+
+def test_augment_uls_terms_with_default_order_appends_rows():
+    model = UOFR(sobolev_order=1, basis_function=Polynomial(degree=1))
+    y_sample = np.arange(11.0).reshape(-1, 1)
+    psi_sample = np.column_stack((np.arange(11.0), np.arange(11.0)))
+    y_aug, psi_aug = model.augment_uls_terms(y_sample, psi_sample)
+    assert y_aug.shape[0] == 22
+    assert psi_aug.shape[0] == 22
+
+
+def test_sobolev_error_reduction_ratio_respects_err_tol():
+    model = UOFR(
+        sobolev_order=0,
+        ylag=1,
+        xlag=1,
+        elag=1,
+        err_tol=0.0,
+        basis_function=Polynomial(degree=1),
+    )
+    y_sample = np.arange(6.0).reshape(-1, 1)
+    psi_sample = np.column_stack(
+        (
+            np.linspace(0.1, 0.5, 5),
+            np.linspace(0.6, 1.0, 5),
+        )
+    )
+    err, piv, psi_ortho, y_aug = model.sobolev_error_reduction_ratio(
+        psi_sample,
+        y_sample,
+        process_term_number=2,
+    )
+    assert model.n_terms == 1
+    assert len(piv) == 1
+    assert psi_ortho.shape[1] == 1

--- a/sysidentpy/model_structure_selection/tests/test_uofr.py
+++ b/sysidentpy/model_structure_selection/tests/test_uofr.py
@@ -177,7 +177,7 @@ def test_information_criteria_bic():
         basis_function=basis_function,
     )
     model.fit(X=x, y=y)
-    info_values = np.array([-1959.320155, -2612.875131, -2948.136725, -3300.113919])
+    info_values = np.array([896.976044, 55.273645, -619.342972, -887.017557])
     assert_almost_equal(model.info_values[:4], info_values[:4], decimal=3)
 
 
@@ -194,7 +194,7 @@ def test_information_criteria_aicc():
         basis_function=basis_function,
     )
     model.fit(X=x, y=y)
-    info_values = np.array([-1964.221892, -2622.674577, -2962.82984, -3319.69665])
+    info_values = np.array([892.074090, 45.475397, -634.036991, -906.600820])
     assert_almost_equal(model.info_values[:4], info_values[:4], decimal=3)
 
 
@@ -211,7 +211,7 @@ def test_information_criteria_fpe():
         basis_function=basis_function,
     )
     model.fit(X=x, y=y)
-    info_values = np.array([-1964.225908, -2622.686632, -2962.853966, -3319.736889])
+    info_values = np.array([892.069887, 45.462543, -634.060665, -906.640463])
     assert_almost_equal(model.info_values[:4], info_values[:4], decimal=3)
 
 
@@ -228,7 +228,7 @@ def test_information_criteria_lilc():
         basis_function=basis_function,
     )
     model.fit(X=x, y=y)
-    info_values = np.array([-1962.361199, -2618.957218, -2957.259855, -3312.278093])
+    info_values = np.array([893.935255, 49.192165, -628.466752, -899.181576])
     assert_almost_equal(model.info_values[:4], info_values[:4], decimal=3)
 
 
@@ -352,6 +352,7 @@ def test_gaussian_test_function_order_zero_returns_gaussian():
     )
     t = np.linspace(-1, 1, 7)
     gaussian = np.exp(-(t**2) / (2 * model.gaussian_sigma**2))
+    gaussian[np.abs(t) >= np.max(np.abs(t))] = 0.0
     assert_array_equal(model.gaussian_test_function(t, 0), gaussian)
 
 
@@ -369,8 +370,9 @@ def test_augment_uls_terms_with_default_order_appends_rows():
     y_sample = np.arange(11.0).reshape(-1, 1)
     psi_sample = np.column_stack((np.arange(11.0), np.arange(11.0)))
     y_aug, psi_aug = model.augment_uls_terms(y_sample, psi_sample)
-    assert y_aug.shape[0] == 22
-    assert psi_aug.shape[0] == 22
+    expected_rows = y_sample.shape[0] + (y_sample.shape[0] - model.test_support + 1)
+    assert y_aug.shape[0] == expected_rows
+    assert psi_aug.shape[0] == expected_rows
 
 
 def test_sobolev_error_reduction_ratio_respects_err_tol():


### PR DESCRIPTION
change implementation of normalized and convolution to follow the paper assumptions. Also add bplines functions and use them as default functions, following the paper implementation.