### PR TITLE
Add validation-based early stopping to NARXNN

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,9 @@
 
 ### CHANGES
 
+- **Neural NARX Early Stopping:**
+    - Added optional validation-loss early stopping to `NARXNN` with configurable `patience` and `min_delta`.
+    - Reused the existing `X_test` and `y_test` validation flow and automatically restored the network weights from the best validation epoch.
 - **Array API Testing:**
     - Updated the vendored `array-api-extra` tree from v0.10.1 to v0.11.0, replacing the experimental testing overlay with the complete upstream implementation while retaining the existing hook for vendored `array-api-compat` v1.14.0.
     - Added a narrow test-only assertion facade for SysIdentPy policies around NumPy baselines, Python literals, scalar values, dtype, shape, and namespace validation.
@@ -17,9 +20,11 @@
 
 ### IMPACT
 
-The standard `pip install sysidentpy` installation remains unchanged. Array API testing dependencies continue to be development-only, and the update does not change SysIdentPy's public runtime API.
+The standard `pip install sysidentpy` installation remains unchanged. Array API testing dependencies continue to be development-only. Neural NARX early stopping is opt-in, so existing training behaviour remains unchanged by default.
 
 ### TESTING
+
+Neural NARX tests cover disabled compatibility, validation requirements, patience, minimum improvement, stopping, and best-weight restoration.
 
 The assertion facade is covered with NumPy, `array-api-strict`, and PyTorch CPU arrays, including namespace, dtype, shape, scalar, zero-dimensional tolerance, and non-default-device cases.
 

--- a/docs/en/user-guide/how-to/create-a-narx-neural-network.md
+++ b/docs/en/user-guide/how-to/create-a-narx-neural-network.md
@@ -93,7 +93,9 @@ x_train, x_valid, y_train, y_valid = get_siso_data(
 
 One can create a NARXNN object and choose the maximum lag of both input and output for building the regressor matrix to serve as input of the network.
 
-In addition, you can choose the loss function, the optimizer, the optional parameters of the optimizer, the number of epochs.
+In addition, you can choose the loss function, the optimizer, the optional parameters of the optimizer, and the number of epochs.
+
+Early stopping can be enabled with `early_stopping=True`. It monitors the validation loss computed from the `X_test` and `y_test` data passed to `fit`, stops after `patience` consecutive epochs without an improvement greater than `min_delta`, and restores the network weights with the lowest observed validation loss.
 
 Because we built this feature on top of Pytorch, you can choose any of the loss function of the torch.nn.functional. [Click here](https://pytorch.org/docs/stable/nn.functional.html#loss-functions) for a list of the loss functions you can use. You just need to pass the name of the loss function you want.
 
@@ -113,6 +115,9 @@ narx_net = NARXNN(
     loss_func="mse_loss",
     optimizer="Adam",
     epochs=2000,
+    early_stopping=True,
+    patience=20,
+    min_delta=1e-4,
     verbose=False,
     device="cuda",
     optim_params={

--- a/docs/pt/user-guide/how-to/create-a-narx-neural-network.md
+++ b/docs/pt/user-guide/how-to/create-a-narx-neural-network.md
@@ -94,6 +94,8 @@ Você pode criar um objeto NARXNN e escolher o lag máximo tanto da entrada quan
 
 Além disso, você pode escolher a função de perda, o otimizador, os parâmetros opcionais do otimizador e o número de épocas.
 
+O early stopping pode ser ativado com `early_stopping=True`. Ele monitora a loss de validação calculada com os dados `X_test` e `y_test` passados para `fit`, interrompe o treinamento após `patience` épocas consecutivas sem uma melhoria maior que `min_delta` e restaura os pesos correspondentes à menor loss de validação observada.
+
 Como construímos esta funcionalidade sobre o Pytorch, você pode escolher qualquer função de perda do torch.nn.functional. [Clique aqui](https://pytorch.org/docs/stable/nn.functional.html#loss-functions) para uma lista das funções de perda disponíveis. Você só precisa passar o nome da função de perda desejada.
 
 Da mesma forma, você pode escolher qualquer otimizador do torch.optim. [Clique aqui](https://pytorch.org/docs/stable/optim.html) para uma lista de otimizadores disponíveis.
@@ -112,6 +114,9 @@ narx_net = NARXNN(
     loss_func="mse_loss",
     optimizer="Adam",
     epochs=2000,
+    early_stopping=True,
+    patience=20,
+    min_delta=1e-4,
     verbose=False,
     device="cuda",
     optim_params={
@@ -337,4 +342,3 @@ plot_residues_correlation(data=x1e, title="Residues", ylabel="$x_1e$")
 # Nota
 
 Lembre-se que você pode usar predição n-steps-ahead e modelos NAR e NFIR. Verifique como usá-los em seus respectivos exemplos.
-

--- a/sysidentpy/neural_network/narx_nn.py
+++ b/sysidentpy/neural_network/narx_nn.py
@@ -9,6 +9,7 @@ import logging
 import sys
 import warnings
 from collections.abc import Mapping
+from copy import deepcopy
 from typing import Optional
 
 import numpy as np
@@ -47,14 +48,13 @@ def _check_cuda(device):
     if device == "cpu":
         return torch.device("cpu")
 
-    if device == "cuda":
-        if torch.cuda.is_available():
-            return torch.device("cuda")
+    if torch.cuda.is_available():
+        return torch.device("cuda")
 
-        warnings.warn(
-            "No CUDA available. We set the device as CPU",
-            stacklevel=2,
-        )
+    warnings.warn(
+        "No CUDA available. We set the device as CPU",
+        stacklevel=2,
+    )
 
     return torch.device("cpu")
 
@@ -140,6 +140,14 @@ class NARXNN(BaseMSS):
         Controls the seeding used to reset the neural network parameters before
         training. When provided, the model weights are reinitialized with the
         same seed at every call to ``fit`` to guarantee deterministic behaviour.
+    early_stopping : bool, default=False
+        Whether to stop training when the validation loss stops improving. Validation
+        data must be provided through ``X_test`` and ``y_test`` when calling ``fit``.
+    patience : int, default=10
+        Number of consecutive epochs without sufficient validation loss improvement
+        before training is stopped. Only used when ``early_stopping=True``.
+    min_delta : float, default=0.0
+        Minimum decrease in validation loss required to qualify as an improvement.
 
     Examples
     --------
@@ -219,6 +227,9 @@ class NARXNN(BaseMSS):
         device="cpu",
         shuffle_batches=False,
         random_state: Optional[int] = None,
+        early_stopping=False,
+        patience=10,
+        min_delta=0.0,
     ):
         if torch is None:
             raise ImportError(
@@ -245,6 +256,9 @@ class NARXNN(BaseMSS):
         self.verbose = verbose
         self.shuffle_batches = shuffle_batches
         self.random_state = random_state
+        self.early_stopping = early_stopping
+        self.patience = patience
+        self.min_delta = min_delta
         if optim_params is None:
             self.optim_params = {}
         elif isinstance(optim_params, Mapping):
@@ -288,6 +302,30 @@ class NARXNN(BaseMSS):
         if not isinstance(self.shuffle_batches, bool):
             raise TypeError(
                 f"shuffle_batches must be False or True. Got {self.shuffle_batches}"
+            )
+
+        if not isinstance(self.early_stopping, bool):
+            raise TypeError(
+                f"early_stopping must be False or True. Got {self.early_stopping}"
+            )
+
+        if (
+            isinstance(self.patience, bool)
+            or not isinstance(self.patience, (int, np.integer))
+            or self.patience < 1
+        ):
+            raise ValueError(
+                f"patience must be integer and > zero. Got {self.patience}"
+            )
+
+        if (
+            isinstance(self.min_delta, bool)
+            or not isinstance(self.min_delta, (int, float, np.integer, np.floating))
+            or not np.isfinite(self.min_delta)
+            or self.min_delta < 0
+        ):
+            raise ValueError(
+                f"min_delta must be a finite number and >= zero. Got {self.min_delta}"
             )
 
         self.ylag = self._sanitize_lag(self.ylag, "ylag")
@@ -525,6 +563,13 @@ class NARXNN(BaseMSS):
         if y is None:
             raise ValueError("y cannot be None")
 
+        self.max_lag = self._get_max_lag()
+        if len(y) <= self.max_lag:
+            raise ValueError(
+                "y must contain more samples than the maximum lag. "
+                f"Got {len(y)} samples and max_lag={self.max_lag}"
+            )
+
         x_train, y_train = self.split_data(x, y)
         train_ds = convert_to_tensor(x_train, y_train)
         train_dl = self.get_data(train_ds, shuffle=shuffle)
@@ -544,9 +589,11 @@ class NARXNN(BaseMSS):
         y : ndarray of floats
             The output data to be used in the training process.
         X_test : ndarray of floats
-            The input data to be used in the prediction process.
+            The input data to be used in the validation process. Required when
+            ``verbose=True`` or ``early_stopping=True``.
         y_test : ndarray of floats
-            The output data (initial conditions) to be used in the prediction process.
+            The output data to be used in the validation process. Required when
+            ``verbose=True`` or ``early_stopping=True``.
 
         Returns
         -------
@@ -558,6 +605,17 @@ class NARXNN(BaseMSS):
             The validation loss of each batch
 
         """
+        monitor_validation = self.verbose or self.early_stopping
+        if monitor_validation and (X_test is None or y_test is None):
+            if self.early_stopping:
+                raise ValueError(
+                    "X_test and y_test cannot be None if you set early_stopping=True"
+                )
+            raise ValueError("X_test and y_test cannot be None if you set verbose=True")
+
+        if self.net is None:
+            raise ValueError("The neural network must be defined before training")
+
         xp = get_namespace(y) if X is None else get_namespace(X, y)
         _require_numpy_namespace(xp, feature="NARXNN", dependency="PyTorch/NumPy")
 
@@ -566,16 +624,16 @@ class NARXNN(BaseMSS):
             self._reset_network_parameters()
 
         train_dl = self.data_transform(X, y, shuffle=self.shuffle_batches)
-        if self.verbose:
-            if X_test is None or y_test is None:
-                raise ValueError(
-                    "X_test and y_test cannot be None if you set verbose=True"
-                )
+        if monitor_validation:
             valid_dl = self.data_transform(X_test, y_test, shuffle=False)
 
         opt = self.define_opt()
         self.val_loss = []
         self.train_loss = []
+        best_val_loss = float("inf")
+        patience_reference_loss = float("inf")
+        best_state = None
+        epochs_without_improvement = 0
         for epoch in range(self.epochs):
             self.net.train()
             epoch_loss = 0.0
@@ -584,11 +642,11 @@ class NARXNN(BaseMSS):
                 X_batch = input_data.to(self.device, non_blocking=True)
                 y_batch = output_data.to(self.device, non_blocking=True)
                 batch_loss, batch_size = self.loss_batch(X_batch, y_batch, opt=opt)
-                if self.verbose:
+                if monitor_validation:
                     epoch_loss += batch_loss * batch_size
                     seen_samples += batch_size
 
-            if self.verbose:
+            if monitor_validation:
                 train_metric = epoch_loss / max(seen_samples, 1)
                 self.train_loss.append(train_metric)
 
@@ -603,12 +661,37 @@ class NARXNN(BaseMSS):
                         )
                         val_loss += loss_val * batch_size
                         val_count += batch_size
-                self.val_loss.append(val_loss / max(val_count, 1))
-                logging.info(
-                    "Train metrics: %s | Validation metrics: %s",
-                    self.train_loss[epoch],
-                    self.val_loss[epoch],
-                )
+                validation_metric = val_loss / max(val_count, 1)
+                self.val_loss.append(validation_metric)
+
+                if self.early_stopping:
+                    if not np.isfinite(validation_metric):
+                        raise ValueError(
+                            "Validation loss must be finite when early stopping is "
+                            f"enabled. Got {validation_metric}"
+                        )
+                    if validation_metric < best_val_loss:
+                        best_val_loss = validation_metric
+                        best_state = deepcopy(self.net.state_dict())
+
+                    if validation_metric < patience_reference_loss - self.min_delta:
+                        patience_reference_loss = validation_metric
+                        epochs_without_improvement = 0
+                    else:
+                        epochs_without_improvement += 1
+
+                if self.verbose:
+                    logging.info(
+                        "Train metrics: %s | Validation metrics: %s",
+                        self.train_loss[epoch],
+                        self.val_loss[epoch],
+                    )
+
+                if self.early_stopping and epochs_without_improvement >= self.patience:
+                    break
+
+        if self.early_stopping and best_state is not None:
+            self.net.load_state_dict(best_state)
         return self
 
     def predict(self, *, X=None, y=None, steps_ahead=None, forecast_horizon=None):

--- a/sysidentpy/neural_network/tests/test_narx_nn_branches.py
+++ b/sysidentpy/neural_network/tests/test_narx_nn_branches.py
@@ -1,8 +1,12 @@
+import builtins
 from collections import deque
+import importlib.util
+from pathlib import Path
 from types import SimpleNamespace
 
 import numpy as np
 import pytest
+import torch
 
 import sysidentpy.neural_network.narx_nn as narx_module
 from sysidentpy.basis_function import Polynomial
@@ -31,6 +35,48 @@ def _make_model(**kwargs):
     return model
 
 
+class _EarlyStoppingNet(torch.nn.Module):
+    def __init__(self):
+        super().__init__()
+        self.weight = torch.nn.Parameter(torch.tensor(0.0))
+
+    def forward(self, x):
+        return x[:, :1] * self.weight
+
+
+def _fit_with_validation_losses(monkeypatch, validation_losses, **kwargs):
+    net = _EarlyStoppingNet()
+    model = _make_model(
+        net=net,
+        early_stopping=True,
+        epochs=kwargs.pop("epochs", len(validation_losses)),
+        **kwargs,
+    )
+    batch = (
+        torch.ones((2, 1), dtype=torch.float32),
+        torch.ones((2, 1), dtype=torch.float32),
+    )
+    loaders = deque([[batch], [batch]])
+    epochs_completed = 0
+
+    monkeypatch.setattr(model, "data_transform", lambda *a, **k: loaders.popleft())
+    monkeypatch.setattr(model, "define_opt", object)
+
+    def fake_loss_batch(x, _y, opt=None):
+        nonlocal epochs_completed
+        if opt is not None:
+            epochs_completed += 1
+            with torch.no_grad():
+                net.weight.fill_(epochs_completed)
+            return 0.5, len(x)
+        return validation_losses[epochs_completed - 1], len(x)
+
+    monkeypatch.setattr(model, "loss_batch", fake_loss_batch)
+    data = np.ones((4, 1), dtype=np.float32)
+    model.fit(X=data, y=data, X_test=data, y_test=data)
+    return model, epochs_completed
+
+
 def test_loss_func_must_be_string():
     with pytest.raises(TypeError, match="loss_func must be provided as string"):
         _make_model(loss_func=123)
@@ -39,6 +85,61 @@ def test_loss_func_must_be_string():
 def test_optimizer_must_be_string():
     with pytest.raises(TypeError, match="optimizer must be provided as string"):
         _make_model(optimizer=object())
+
+
+def test_optional_torch_import_paths(monkeypatch):
+    original_import = builtins.__import__
+
+    def import_without_torch(name, *args, **kwargs):
+        if name == "torch" or name.startswith("torch."):
+            raise ImportError("torch intentionally unavailable")
+        return original_import(name, *args, **kwargs)
+
+    monkeypatch.setattr(builtins, "__import__", import_without_torch)
+    spec = importlib.util.spec_from_file_location(
+        "sysidentpy.neural_network._narx_nn_without_torch",
+        narx_module.__file__,
+    )
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+
+    assert module.torch is None
+    with pytest.raises(ImportError, match="PyTorch is required"):
+        module.NARXNN()
+
+    def import_without_narx_nn(name, globals=None, locals=None, fromlist=(), level=0):
+        if name == "narx_nn" and level == 1:
+            raise ImportError("narx_nn intentionally unavailable")
+        return original_import(name, globals, locals, fromlist, level)
+
+    monkeypatch.setattr(builtins, "__import__", import_without_narx_nn)
+    init_path = Path(narx_module.__file__).with_name("__init__.py")
+    package_spec = importlib.util.spec_from_file_location(
+        "sysidentpy.neural_network",
+        init_path,
+        submodule_search_locations=[str(init_path.parent)],
+    )
+    package = importlib.util.module_from_spec(package_spec)
+    package_spec.loader.exec_module(package)
+    assert not hasattr(package, "NARXNN")
+
+
+@pytest.mark.parametrize(
+    ("kwargs", "exception", "message"),
+    [
+        ({"early_stopping": 1}, TypeError, "early_stopping must be False or True"),
+        ({"patience": 0}, ValueError, "patience must be integer and > zero"),
+        ({"patience": 1.5}, ValueError, "patience must be integer and > zero"),
+        ({"patience": True}, ValueError, "patience must be integer and > zero"),
+        ({"min_delta": -0.1}, ValueError, "min_delta must be a finite number"),
+        ({"min_delta": np.inf}, ValueError, "min_delta must be a finite number"),
+        ({"min_delta": True}, ValueError, "min_delta must be a finite number"),
+        ({"min_delta": "0"}, ValueError, "min_delta must be a finite number"),
+    ],
+)
+def test_early_stopping_parameter_validation(kwargs, exception, message):
+    with pytest.raises(exception, match=message):
+        _make_model(**kwargs)
 
 
 def test_sanitize_lag_validations():
@@ -118,10 +219,44 @@ def test_seed_torch_generators_calls_cuda_seed(monkeypatch):
     assert calls["cuda"] == 4
 
 
+def test_seed_torch_generators_ignores_missing_random_state(monkeypatch):
+    model = _make_model(random_state=None)
+    monkeypatch.setattr(
+        narx_module.torch,
+        "manual_seed",
+        lambda *_args: pytest.fail("manual_seed should not be called"),
+    )
+
+    model._seed_torch_generators()
+
+
+def test_loss_batch_without_optimizer_does_not_update_weights():
+    net = torch.nn.Linear(1, 1)
+    model = _make_model(net=net)
+    x = torch.ones((2, 1), dtype=torch.float32)
+    y = torch.zeros((2, 1), dtype=torch.float32)
+    weights_before = {
+        name: value.detach().clone() for name, value in net.state_dict().items()
+    }
+
+    loss, batch_size = model.loss_batch(x, y)
+
+    assert np.isfinite(loss)
+    assert batch_size == 2
+    for name, value in net.state_dict().items():
+        torch.testing.assert_close(value, weights_before[name])
+
+
 def test_split_data_requires_y():
     model = _make_model()
     with pytest.raises(ValueError, match="y cannot be None"):
         model.split_data(np.ones((4, 1), dtype=np.float32), None)
+
+
+def test_data_transform_requires_y():
+    model = _make_model()
+    with pytest.raises(ValueError, match="y cannot be None"):
+        model.data_transform(np.ones((4, 1), dtype=np.float32), None)
 
 
 def test_split_data_with_none_input_sets_default_inputs(monkeypatch):
@@ -198,6 +333,243 @@ def test_fit_verbose_tracks_losses(monkeypatch):
     assert model.val_loss == [0.5]
 
 
+def test_fit_without_early_stopping_runs_all_epochs(monkeypatch):
+    model = _make_model(net=_EarlyStoppingNet(), epochs=4)
+    batch = (
+        torch.ones((2, 1), dtype=torch.float32),
+        torch.ones((2, 1), dtype=torch.float32),
+    )
+    transform_calls = 0
+    epochs_completed = 0
+
+    def fake_data_transform(*_args, **_kwargs):
+        nonlocal transform_calls
+        transform_calls += 1
+        return [batch]
+
+    def fake_loss_batch(x, _y, opt=None):
+        nonlocal epochs_completed
+        assert opt is not None
+        epochs_completed += 1
+        return 0.5, len(x)
+
+    monkeypatch.setattr(model, "data_transform", fake_data_transform)
+    monkeypatch.setattr(model, "define_opt", object)
+    monkeypatch.setattr(model, "loss_batch", fake_loss_batch)
+
+    data = np.ones((4, 1), dtype=np.float32)
+    model.fit(X=data, y=data)
+
+    assert epochs_completed == model.epochs
+    assert transform_calls == 1
+    assert model.train_loss == []
+    assert model.val_loss == []
+
+
+def test_fit_requires_defined_network():
+    model = _make_model()
+    data = np.ones((4, 1), dtype=np.float32)
+
+    with pytest.raises(ValueError, match="defined before training"):
+        model.fit(X=data, y=data)
+
+
+def test_early_stopping_requires_validation_data(monkeypatch):
+    model = _make_model(net=_EarlyStoppingNet(), early_stopping=True, epochs=1)
+    batch = (
+        torch.ones((2, 1), dtype=torch.float32),
+        torch.ones((2, 1), dtype=torch.float32),
+    )
+    monkeypatch.setattr(model, "data_transform", lambda *a, **k: [batch])
+
+    data = np.ones((4, 1), dtype=np.float32)
+    with pytest.raises(ValueError, match="early_stopping=True"):
+        model.fit(X=data, y=data)
+
+
+def test_invalid_early_stopping_fit_does_not_reset_network():
+    net = torch.nn.Linear(2, 1)
+    model = _make_model(
+        net=net,
+        random_state=7,
+        early_stopping=True,
+        epochs=1,
+    )
+    state_before = {
+        name: value.detach().clone() for name, value in net.state_dict().items()
+    }
+    data = np.ones((4, 1), dtype=np.float32)
+
+    with pytest.raises(ValueError, match="early_stopping=True"):
+        model.fit(X=data, y=data)
+
+    for name, value in net.state_dict().items():
+        torch.testing.assert_close(value, state_before[name])
+
+
+def test_data_transform_rejects_data_without_post_lag_samples():
+    model = _make_model()
+    data = np.ones((1, 1), dtype=np.float32)
+
+    with pytest.raises(ValueError, match="more samples than the maximum lag"):
+        model.data_transform(data, data)
+
+
+def test_early_stopping_interrupts_and_restores_best_weights(monkeypatch):
+    model, epochs_completed = _fit_with_validation_losses(
+        monkeypatch,
+        [1.0, 0.8, 0.9, 0.7, 0.6],
+        patience=1,
+    )
+
+    assert epochs_completed == 3
+    assert model.train_loss == [0.5, 0.5, 0.5]
+    assert model.val_loss == [1.0, 0.8, 0.9]
+    assert model.net.weight.item() == pytest.approx(2.0)
+
+
+def test_early_stopping_patience_resets_after_improvement(monkeypatch):
+    model, epochs_completed = _fit_with_validation_losses(
+        monkeypatch,
+        [1.0, 1.1, 0.9, 1.0, 1.1, 0.5],
+        patience=2,
+    )
+
+    assert epochs_completed == 5
+    assert model.val_loss == [1.0, 1.1, 0.9, 1.0, 1.1]
+    assert model.net.weight.item() == pytest.approx(3.0)
+
+
+def test_early_stopping_respects_min_delta(monkeypatch):
+    model, epochs_completed = _fit_with_validation_losses(
+        monkeypatch,
+        [1.0, 0.95, 0.7],
+        patience=1,
+        min_delta=0.1,
+    )
+
+    assert epochs_completed == 2
+    assert model.val_loss == [1.0, 0.95]
+    assert model.net.weight.item() == pytest.approx(2.0)
+
+
+def test_early_stopping_restores_best_weights_after_all_epochs(monkeypatch):
+    model, epochs_completed = _fit_with_validation_losses(
+        monkeypatch,
+        [1.0, 0.5, 0.75],
+        patience=10,
+    )
+
+    assert epochs_completed == 3
+    assert model.net.weight.item() == pytest.approx(2.0)
+
+
+def test_early_stopping_accumulates_small_improvements(monkeypatch):
+    model, epochs_completed = _fit_with_validation_losses(
+        monkeypatch,
+        [1.0, 0.95, 0.89, 0.90, 0.91],
+        patience=2,
+        min_delta=0.1,
+    )
+
+    assert epochs_completed == 5
+    assert model.net.weight.item() == pytest.approx(3.0)
+
+
+def test_early_stopping_rejects_non_finite_validation_loss(monkeypatch):
+    with pytest.raises(ValueError, match="Validation loss must be finite"):
+        _fit_with_validation_losses(monkeypatch, [np.nan], patience=1)
+
+
+def test_validation_loss_is_weighted_by_batch_size(monkeypatch):
+    model = _make_model(net=_EarlyStoppingNet(), epochs=1, verbose=True)
+    train_batch = (
+        torch.ones((3, 1), dtype=torch.float32),
+        torch.ones((3, 1), dtype=torch.float32),
+    )
+    validation_batches = [
+        (
+            torch.ones((2, 1), dtype=torch.float32),
+            torch.ones((2, 1), dtype=torch.float32),
+        ),
+        (
+            torch.ones((1, 1), dtype=torch.float32),
+            torch.ones((1, 1), dtype=torch.float32),
+        ),
+    ]
+    loaders = deque([[train_batch], validation_batches])
+
+    monkeypatch.setattr(model, "data_transform", lambda *a, **k: loaders.popleft())
+    monkeypatch.setattr(model, "define_opt", object)
+
+    def fake_loss_batch(x, _y, opt=None):
+        if opt is not None:
+            return 2.0, len(x)
+        return (1.0 if len(x) == 2 else 4.0), len(x)
+
+    monkeypatch.setattr(model, "loss_batch", fake_loss_batch)
+    data = np.ones((4, 1), dtype=np.float32)
+
+    model.fit(X=data, y=data, X_test=data, y_test=data)
+
+    assert model.train_loss == [2.0]
+    assert model.val_loss == [2.0]
+
+
+def test_repeated_early_stopping_fits_are_independent():
+    data = np.linspace(0.0, 1.0, 12, dtype=np.float32).reshape(-1, 1)
+    y = 0.5 * data
+    net = torch.nn.Sequential(
+        torch.nn.Linear(2, 4),
+        torch.nn.Tanh(),
+        torch.nn.Linear(4, 1),
+    )
+    model = _make_model(
+        net=net,
+        basis_function=Polynomial(degree=1),
+        epochs=5,
+        learning_rate=0.0,
+        optimizer="SGD",
+        random_state=3,
+        early_stopping=True,
+        patience=2,
+    )
+
+    model.fit(X=data[:8], y=y[:8], X_test=data[8:], y_test=y[8:])
+    first_losses = model.val_loss.copy()
+    first_state = {
+        name: value.detach().clone() for name, value in net.state_dict().items()
+    }
+
+    model.fit(X=data[:8], y=y[:8], X_test=data[8:], y_test=y[8:])
+
+    assert len(first_losses) == len(model.val_loss) == 3
+    np.testing.assert_allclose(model.val_loss, first_losses, rtol=0, atol=0)
+    for name, value in net.state_dict().items():
+        torch.testing.assert_close(value, first_state[name])
+
+
+@pytest.mark.skipif(not torch.cuda.is_available(), reason="CUDA is unavailable")
+def test_early_stopping_preserves_cuda_model_device():
+    data = np.linspace(0.0, 1.0, 8, dtype=np.float32).reshape(-1, 1)
+    y = 0.5 * data
+    net = torch.nn.Linear(2, 1).to("cuda")
+    model = _make_model(
+        net=net,
+        basis_function=Polynomial(degree=1),
+        device="cuda",
+        epochs=3,
+        learning_rate=0.0,
+        early_stopping=True,
+        patience=1,
+    )
+
+    model.fit(X=data[:5], y=y[:5], X_test=data[5:], y_test=y[5:])
+
+    assert len(model.val_loss) == 2
+    assert all(parameter.device.type == "cuda" for parameter in net.parameters())
+
+
 def test_one_step_prediction_requires_y():
     model = _make_model()
     with pytest.raises(ValueError, match="y cannot be None"):
@@ -223,6 +595,34 @@ def test_model_prediction_invalid_type():
             np.ones((2, 1), dtype=np.float32),
             np.ones((2, 1), dtype=np.float32),
         )
+
+
+def test_model_prediction_dispatches_nfir(monkeypatch):
+    model = _make_model(model_type="NFIR")
+    expected = np.ones((2, 1), dtype=np.float32)
+    monkeypatch.setattr(model, "_nfir_predict", lambda *_args: expected)
+
+    result = model._model_prediction(
+        np.ones((2, 1), dtype=np.float32),
+        np.ones((2, 1), dtype=np.float32),
+    )
+
+    assert result is expected
+
+
+def test_predict_preserves_eval_mode(monkeypatch):
+    model = _make_model(net=_EarlyStoppingNet())
+    model.net.eval()
+    expected = np.ones((2, 1), dtype=np.float32)
+    monkeypatch.setattr(model, "_model_prediction", lambda *_args, **_kwargs: expected)
+
+    result = model.predict(
+        X=np.ones((2, 1), dtype=np.float32),
+        y=np.ones((2, 1), dtype=np.float32),
+    )
+
+    assert result is expected
+    assert model.net.training is False
 
 
 def test_narmax_predict_requires_enough_initial_conditions():

--- a/sysidentpy/neural_network/tests/test_narxnn.py
+++ b/sysidentpy/neural_network/tests/test_narxnn.py
@@ -75,6 +75,9 @@ def test_default_values():
         "verbose": False,
         "optim_params": {},
         "random_state": None,
+        "early_stopping": False,
+        "patience": 10,
+        "min_delta": 0.0,
     }
     model = NARXNN(basis_function=Polynomial())
     model_values = [
@@ -91,6 +94,9 @@ def test_default_values():
         model.verbose,
         model.optim_params,
         model.random_state,
+        model.early_stopping,
+        model.patience,
+        model.min_delta,
     ]
     assert list(default.values()) == model_values
 


### PR DESCRIPTION
## Summary

- add optional validation-based early stopping to `NARXNN`
- support configurable `patience` and `min_delta`
- reuse `X_test` and `y_test` as validation data
- restore weights from the lowest observed validation loss
- preserve existing behavior when early stopping is disabled
- validate invalid configurations, missing validation data, non-finite losses, and insufficient samples
- document the feature in the EN/PT guides and changelog

Closes #108