### PR TITLE
fix NAR n-step prediction across estimators

### DIFF
--- a/sysidentpy/general_estimators/narx.py
+++ b/sysidentpy/general_estimators/narx.py
@@ -291,39 +291,6 @@ class NARX(BaseMSS):
         yhat = self.base_estimator.predict(x_base)
         return yhat.reshape(-1, 1)
 
-    def _nar_step_ahead(self, y, steps_ahead):
-        if len(y) < self.max_lag:
-            raise ValueError(
-                "Insufficient initial condition elements! Expected at least"
-                f" {self.max_lag} elements."
-            )
-
-        to_remove = int(np.ceil((len(y) - self.max_lag) / steps_ahead))
-        yhat = np.zeros(len(y) + steps_ahead, dtype=float)
-        yhat.fill(np.nan)
-        yhat[: self.max_lag] = y[: self.max_lag, 0]
-        i = self.max_lag
-
-        steps = [step for step in range(0, to_remove * steps_ahead, steps_ahead)]
-        if len(steps) > 1:
-            for step in steps[:-1]:
-                yhat[i : i + steps_ahead] = self._model_prediction(
-                    x=None, y_initial=y[step:i], forecast_horizon=steps_ahead
-                )[-steps_ahead:].ravel()
-                i += steps_ahead
-
-            steps_ahead = np.sum(np.isnan(yhat))
-            yhat[i : i + steps_ahead] = self._model_prediction(
-                x=None, y_initial=y[steps[-1] : i]
-            )[-steps_ahead:].ravel()
-        else:
-            yhat[i : i + steps_ahead] = self._model_prediction(
-                x=None, y_initial=y[0:i], forecast_horizon=steps_ahead
-            )[-steps_ahead:].ravel()
-
-        yhat = yhat.ravel()[self.max_lag : :]
-        return yhat.reshape(-1, 1)
-
     def narmax_n_step_ahead(self, x, y, steps_ahead):
         """N steps ahead prediction method for NARMAX model."""
         if len(y) < self.max_lag:

--- a/sysidentpy/general_estimators/tests/test_general_narx.py
+++ b/sysidentpy/general_estimators/tests/test_general_narx.py
@@ -1,9 +1,11 @@
 # pylint: disable=protected-access
 # pyright: reportMissingTypeStubs=false
 import numpy as np
+import pytest
 from sklearn.linear_model import LinearRegression  # type: ignore[reportMissingTypeStubs]
 from unittest.mock import MagicMock
 from numpy.testing import (
+    assert_allclose,
     assert_almost_equal,
     assert_equal,
     assert_raises,
@@ -59,6 +61,27 @@ def fit_narx_model(
     )
     model.fit(X=x_data, y=y_data)
     return model
+
+
+def segmented_nar_prediction(model, y_data, steps_ahead):
+    """Build an n-step NAR reference from independent free-run segments."""
+    reference = np.empty_like(y_data)
+    reference[: model.max_lag] = y_data[: model.max_lag]
+
+    for block_start in range(model.max_lag, len(y_data), steps_ahead):
+        block_horizon = min(steps_ahead, len(y_data) - block_start)
+        y_initial = y_data[block_start - model.max_lag : block_start]
+        block_prediction = model.predict(
+            X=None,
+            y=y_initial,
+            steps_ahead=None,
+            forecast_horizon=block_horizon,
+        )
+        reference[block_start : block_start + block_horizon] = block_prediction[
+            -block_horizon:
+        ]
+
+    return reference
 
 
 def test_default_values():
@@ -402,17 +425,72 @@ def test_nar_step_ahead_multi_segment_prediction():
     )
     steps = 3
     yhat = model._nar_step_ahead(y_test, steps_ahead=steps)
-    expected = y_test.shape[0] + steps - model.max_lag
-    assert_equal(yhat.shape[0], expected)
-    assert_equal(model._model_prediction.called, True)
+    prediction_count = y_test.shape[0] - model.max_lag
+    expected_horizons = [
+        min(steps, prediction_count - start)
+        for start in range(0, prediction_count, steps)
+    ]
+    expected_values = np.concatenate(
+        [np.arange(100, dtype=float)[-horizon:] for horizon in expected_horizons]
+    )
+
+    assert_equal(yhat.shape, (prediction_count, 1))
+    assert_allclose(yhat[:, 0], expected_values)
+    assert [
+        call.kwargs["forecast_horizon"]
+        for call in model._model_prediction.call_args_list
+    ] == expected_horizons
+    for block, call in enumerate(model._model_prediction.call_args_list):
+        start = block * steps
+        assert_allclose(call.kwargs["y_initial"], y_test[start : start + model.max_lag])
 
 
 def test_nar_step_ahead_single_segment_prediction():
     model = fit_narx_model(model_type="NAR", x_data=None)
     y_small = y_test[: model.max_lag + 1]
     yhat = model._nar_step_ahead(y_small, steps_ahead=4)
-    expected = y_small.shape[0] + 4 - model.max_lag
-    assert_equal(yhat.shape[0], expected)
+    expected = model._model_prediction(
+        x=None,
+        y_initial=y_small[: model.max_lag],
+        forecast_horizon=1,
+    )
+    assert_equal(yhat.shape, (1, 1))
+    assert_allclose(yhat, expected)
+
+
+@pytest.mark.parametrize("include_bias", [True, False])
+@pytest.mark.parametrize("steps_ahead", [2, 3])
+def test_nar_n_step_prediction_matches_segmented_free_runs(include_bias, steps_ahead):
+    model = fit_narx_model(
+        model_type="NAR",
+        basis_function=Polynomial(degree=2, include_bias=include_bias),
+        x_data=None,
+    )
+    y_evaluation = y_test[:25]
+
+    expected = segmented_nar_prediction(model, y_evaluation, steps_ahead)
+    yhat = model.predict(X=None, y=y_evaluation, steps_ahead=steps_ahead)
+
+    assert_equal(yhat.shape, y_evaluation.shape)
+    assert_allclose(yhat[: model.max_lag], y_evaluation[: model.max_lag])
+    assert_allclose(yhat, expected)
+
+
+def test_nar_step_larger_than_remaining_horizon_matches_single_free_run():
+    model = fit_narx_model(model_type="NAR", x_data=None)
+    y_evaluation = y_test[: model.max_lag + 4]
+    steps_ahead = len(y_evaluation)
+
+    expected = model.predict(
+        X=None,
+        y=y_evaluation[: model.max_lag],
+        steps_ahead=None,
+        forecast_horizon=len(y_evaluation) - model.max_lag,
+    )
+    yhat = model.predict(X=None, y=y_evaluation, steps_ahead=steps_ahead)
+
+    assert_equal(yhat.shape, y_evaluation.shape)
+    assert_allclose(yhat, expected)
 
 
 def test_narmax_n_step_ahead_requires_initial_conditions():
@@ -436,7 +514,7 @@ def test_nar_n_step_prediction_path():
     )
     steps = 2
     yhat = model._n_step_ahead_prediction(None, y_test, steps_ahead=steps)
-    expected = y_test.shape[0] + steps - model.max_lag
+    expected = y_test.shape[0] - model.max_lag
     assert_equal(yhat.shape[0], expected)
 
 

--- a/sysidentpy/narmax_base.py
+++ b/sysidentpy/narmax_base.py
@@ -25,6 +25,7 @@ from sysidentpy._lib._array_api import (
     device as _device,
     get_namespace,
 )
+from sysidentpy.utils.check_arrays import check_positive_int
 from sysidentpy.utils.information_matrix import (
     build_output_matrix,
     build_input_matrix,
@@ -40,6 +41,15 @@ def _find_method_owner(cls: type, method_name: str) -> Optional[type]:
         if method_name in parent.__dict__:
             return parent
     return None
+
+
+def _recursive_prediction_dtype(xp, dtype):
+    """Return a floating dtype when recursive prediction inputs are integral."""
+    if _is_numpy_namespace(xp):
+        return np.dtype(float) if np.dtype(dtype).kind in "biu" else dtype
+    if xp.isdtype(dtype, ("bool", "integral")):
+        return xp.asarray(1.0).dtype
+    return dtype
 
 
 class RegressorDictionary:
@@ -443,8 +453,15 @@ class BaseMSS(RegressorDictionary, metaclass=ABCMeta):
         finally:
             self.theta = original_theta
 
+        output_dtype = y.dtype
+        if self.model_type == "NAR":
+            output_dtype = _recursive_prediction_dtype(original_xp, output_dtype)
+
         return _asarray(
-            yhat_np, xp=original_xp, dtype=y.dtype, target_device=target_device
+            yhat_np,
+            xp=original_xp,
+            dtype=output_dtype,
+            target_device=target_device,
         )
 
     def _code2exponents(self, *, code: np.ndarray) -> np.ndarray:
@@ -653,6 +670,9 @@ class BaseMSS(RegressorDictionary, metaclass=ABCMeta):
         """Return the reference recursive NARMAX prediction."""
         xp = get_namespace(x, y_initial)
         _dtype = x.dtype if x is not None else y_initial.dtype
+        if self.model_type == "NAR":
+            _dtype = _recursive_prediction_dtype(xp, _dtype)
+
         target_device = _device(x, y_initial)
         y_output = _zeros(
             xp,
@@ -661,7 +681,12 @@ class BaseMSS(RegressorDictionary, metaclass=ABCMeta):
             target_device=target_device,
         )
         y_output = y_output * float("nan")
-        y_output[: self.max_lag] = y_initial[: self.max_lag, 0]
+        y_output[: self.max_lag] = _asarray(
+            y_initial[: self.max_lag, 0],
+            xp=xp,
+            dtype=_dtype,
+            target_device=target_device,
+        )
 
         model_exponents = _vstack(
             xp,
@@ -818,6 +843,29 @@ class BaseMSS(RegressorDictionary, metaclass=ABCMeta):
         return xp.reshape(y_output[self.max_lag : :], (-1, 1))
 
     def _nar_step_ahead(self, y: np.ndarray, steps_ahead: int) -> np.ndarray:
+        """Return blockwise NAR predictions without initial conditions.
+
+        Parameters
+        ----------
+        y : ndarray of shape (n_samples, 1)
+            Observed output values. The first ``max_lag`` samples provide the
+            initial conditions for the first prediction block.
+        steps_ahead : int
+            Maximum number of recursive predictions in each block.
+
+        Returns
+        -------
+        ndarray of shape (n_samples - max_lag, 1)
+            Predicted values after the initial conditions. Each block restarts
+            from the immediately preceding observed outputs.
+
+        Raises
+        ------
+        ValueError
+            If ``steps_ahead`` is not a positive integer or if ``y`` does not
+            contain enough initial conditions.
+        """
+        check_positive_int(steps_ahead, "steps_ahead")
         xp = get_namespace(y)
         if len(y) < self.max_lag:
             raise ValueError(
@@ -825,38 +873,26 @@ class BaseMSS(RegressorDictionary, metaclass=ABCMeta):
                 f" {self.max_lag} elements."
             )
 
-        to_remove = math.ceil((len(y) - self.max_lag) / steps_ahead)
-        yhat_length = len(y) + steps_ahead
-        yhat = _zeros(xp, yhat_length, dtype=y.dtype, target_device=_device(y))
+        yhat = _zeros(
+            xp,
+            len(y),
+            dtype=_recursive_prediction_dtype(xp, y.dtype),
+            target_device=_device(y),
+        )
         yhat = yhat * float("nan")
-        yhat[: self.max_lag] = y[: self.max_lag, 0]
         i = self.max_lag
 
-        steps = [step for step in range(0, to_remove * steps_ahead, steps_ahead)]
-        if len(steps) > 1:
-            for step in steps[:-1]:
-                yhat[i : i + steps_ahead] = xp.reshape(
-                    self._model_prediction(
-                        x=None, y_initial=y[step:i], forecast_horizon=steps_ahead
-                    )[-steps_ahead:],
-                    (-1,),
-                )
-                i += steps_ahead
-
-            steps_ahead = int(xp.sum(xp.asarray(xp.isnan(yhat), dtype=xp.int32)))
-            yhat[i : i + steps_ahead] = xp.reshape(
-                self._model_prediction(x=None, y_initial=y[steps[-1] : i])[
-                    -steps_ahead:
-                ],
-                (-1,),
-            )
-        else:
-            yhat[i : i + steps_ahead] = xp.reshape(
+        while i < len(y):
+            block_horizon = min(steps_ahead, len(y) - i)
+            yhat[i : i + block_horizon] = xp.reshape(
                 self._model_prediction(
-                    x=None, y_initial=y[0:i], forecast_horizon=steps_ahead
-                )[-steps_ahead:],
+                    x=None,
+                    y_initial=y[i - self.max_lag : i],
+                    forecast_horizon=block_horizon,
+                )[-block_horizon:],
                 (-1,),
             )
+            i += block_horizon
 
         yhat = xp.reshape(yhat, (-1,))[self.max_lag : :]
         return xp.reshape(yhat, (-1, 1))

--- a/sysidentpy/neural_network/narx_nn.py
+++ b/sysidentpy/neural_network/narx_nn.py
@@ -822,6 +822,10 @@ class NARXNN(BaseMSS):
                 f" {self.max_lag} elements."
             )
 
+        if self.model_type == "NAR":
+            yhat = self._nar_step_ahead(y, steps_ahead)
+            return np.concatenate([y[: self.max_lag], yhat], axis=0)
+
         yhat = np.zeros(x.shape[0], dtype=float)
         yhat.fill(np.nan)
         yhat[: self.max_lag] = y[: self.max_lag, 0]

--- a/sysidentpy/neural_network/tests/test_narxnn.py
+++ b/sysidentpy/neural_network/tests/test_narxnn.py
@@ -86,8 +86,47 @@ class _ExpandedPolynomial(Polynomial):
         return features[:, predefined_regressors]
 
 
+class _DeterministicNARNet(nn.Module):
+    def __init__(self):
+        super().__init__()
+        self.linear = nn.Linear(2, 1, bias=False)
+        with torch.no_grad():
+            self.linear.weight.copy_(torch.tensor([[0.4, -0.15]], dtype=torch.float32))
+
+    def forward(self, xb):
+        return self.linear(xb)
+
+
 def _first_regressor_value(values):
     return float(np.asarray(values).reshape(-1)[0])
+
+
+def _build_deterministic_nar_model(y, include_bias):
+    model = NARXNN(
+        net=_DeterministicNARNet(),
+        ylag=2,
+        xlag=2,
+        model_type="NAR",
+        basis_function=Polynomial(degree=1, include_bias=include_bias),
+    )
+    model.split_data(None, y)
+    return model
+
+
+def _segmented_nar_free_run_reference(model, y, steps_ahead):
+    reference = np.empty_like(y, dtype=np.float32)
+    reference[: model.max_lag] = y[: model.max_lag]
+    for start in range(model.max_lag, len(y), steps_ahead):
+        block_horizon = min(steps_ahead, len(y) - start)
+        initial_conditions = y[start - model.max_lag : start]
+        free_run = model.predict(
+            X=None,
+            y=initial_conditions,
+            forecast_horizon=block_horizon,
+        )
+        reference[start : start + block_horizon] = free_run[-block_horizon:]
+
+    return reference
 
 
 def test_default_values():
@@ -261,6 +300,22 @@ def test_polynomial_bias_modes_produce_same_neural_inputs_and_one_step_matrix():
     matrix_without_bias = without_bias_forward.call_args.args[0]
     np.testing.assert_allclose(matrix_with_bias, matrix_without_bias)
     assert matrix_with_bias.shape[1] == with_bias.regressor_code.shape[0]
+
+
+@pytest.mark.parametrize("include_bias", [True, False])
+@pytest.mark.parametrize("steps_ahead", [2, 3, 30])
+def test_polynomial_nar_n_step_matches_segmented_free_run(include_bias, steps_ahead):
+    sample = np.arange(25, dtype=np.float32)
+    y_data = (0.1 * sample + 0.5 * np.sin(sample / 2)).reshape(-1, 1)
+    model = _build_deterministic_nar_model(y_data, include_bias)
+
+    reference = _segmented_nar_free_run_reference(model, y_data, steps_ahead)
+    prediction = model.predict(X=None, y=y_data, steps_ahead=steps_ahead)
+
+    assert prediction.shape == y_data.shape
+    np.testing.assert_array_equal(prediction[: model.max_lag], y_data[: model.max_lag])
+    np.testing.assert_allclose(prediction, reference, rtol=1e-6, atol=1e-6)
+    assert np.all(np.isfinite(prediction))
 
 
 def test_custom_polynomial_layout_removes_only_one_bias_code():

--- a/sysidentpy/simulation/tests/test_simulation.py
+++ b/sysidentpy/simulation/tests/test_simulation.py
@@ -514,6 +514,45 @@ def _small_siso_dataset():
     return get_siso_data(n=200, colored_noise=False, sigma=0.0, train_percentage=80)
 
 
+def _nar_observed_series(n_samples=25):
+    rng = np.random.default_rng(193)
+    y = np.zeros((n_samples, 1))
+    y[:2, 0] = [0.2, -0.1]
+
+    for k in range(2, n_samples):
+        y[k, 0] = 0.55 * y[k - 1, 0] - 0.1 * y[k - 2, 0] + 0.05 + 0.03 * rng.normal()
+
+    return y
+
+
+def _nar_model_and_theta(include_bias):
+    model = np.array([[1001, 0], [1002, 0]])
+    theta = np.array([[0.55], [-0.1]])
+    if include_bias:
+        model = np.concatenate([np.array([[0, 0]]), model], axis=0)
+        theta = np.concatenate([np.array([[0.05]]), theta], axis=0)
+
+    return model, theta
+
+
+def _segmented_nar_free_run_reference(simulator, y, steps_ahead):
+    reference = np.full_like(y, np.nan)
+    reference[: simulator.max_lag] = y[: simulator.max_lag]
+
+    for block_start in range(simulator.max_lag, len(y), steps_ahead):
+        block_horizon = min(steps_ahead, len(y) - block_start)
+        initial_condition = y[block_start - simulator.max_lag : block_start]
+        free_run = simulator.predict(
+            X=None,
+            y=initial_condition,
+            steps_ahead=None,
+            forecast_horizon=block_horizon,
+        )
+        reference[block_start : block_start + block_horizon] = free_run[-block_horizon:]
+
+    return reference
+
+
 def test_simulate_polynomial_without_bias_rejects_bias_model_code():
     _, x_valid, _, y_valid = _small_siso_dataset()
     simulator = SimulateNARMAX(
@@ -741,6 +780,111 @@ def test_predict_paths_cover_all_branches():
     assert multi_step.shape == y_valid.shape
 
 
+@pytest.mark.parametrize("include_bias", [True, False])
+def test_simulate_nar_n_step_matches_segmented_free_runs(include_bias):
+    y = _nar_observed_series()
+    model_code, theta = _nar_model_and_theta(include_bias)
+    simulator = SimulateNARMAX(
+        model_type="NAR",
+        estimate_parameter=False,
+        basis_function=Polynomial(degree=2, include_bias=include_bias),
+    )
+
+    prediction = simulator.simulate(
+        X_test=None,
+        y_test=y,
+        model_code=model_code,
+        theta=theta,
+        steps_ahead=3,
+    )
+    expected = _segmented_nar_free_run_reference(simulator, y, 3)
+
+    assert prediction.shape == y.shape
+    assert np.all(np.isfinite(prediction))
+    np.testing.assert_array_equal(
+        prediction[: simulator.max_lag],
+        y[: simulator.max_lag],
+    )
+    np.testing.assert_allclose(prediction, expected, rtol=1e-12, atol=1e-12)
+    np.testing.assert_allclose(prediction[-2:], expected[-2:], rtol=1e-12, atol=1e-12)
+
+    one_step = simulator.predict(X=None, y=y, steps_ahead=1)
+    one_step_reference = _segmented_nar_free_run_reference(simulator, y, 1)
+    remaining_horizon = int(len(y) - simulator.max_lag)
+    free_run = simulator.predict(
+        X=None,
+        y=y[: simulator.max_lag],
+        forecast_horizon=remaining_horizon,
+    )
+
+    assert one_step.shape == y.shape
+    assert free_run.shape == y.shape
+    assert np.all(np.isfinite(one_step))
+    assert np.all(np.isfinite(free_run))
+    np.testing.assert_array_equal(
+        one_step[: simulator.max_lag],
+        y[: simulator.max_lag],
+    )
+    np.testing.assert_array_equal(
+        free_run[: simulator.max_lag],
+        y[: simulator.max_lag],
+    )
+    np.testing.assert_allclose(
+        one_step,
+        one_step_reference,
+        rtol=1e-12,
+        atol=1e-12,
+    )
+    np.testing.assert_allclose(
+        free_run,
+        _segmented_nar_free_run_reference(
+            simulator,
+            y,
+            remaining_horizon + 1,
+        ),
+        rtol=1e-12,
+        atol=1e-12,
+    )
+
+
+@pytest.mark.parametrize("include_bias", [True, False])
+def test_simulate_nar_recursive_predictions_promote_integer_output(include_bias):
+    y_integer = np.array([[3], [100], [100], [100], [100]])
+    model_code = np.array([[1001]])
+    theta = np.array([[0.5]])
+    if include_bias:
+        model_code = np.array([[0], [1001]])
+        theta = np.array([[0.25], [0.5]])
+        expected_n_step = np.array([[3], [1.75], [1.125], [50.25], [25.375]])
+        expected_free_run = np.array([[3], [1.75], [1.125], [0.8125], [0.65625]])
+    else:
+        expected_n_step = np.array([[3], [1.5], [0.75], [50], [25]])
+        expected_free_run = np.array([[3], [1.5], [0.75], [0.375], [0.1875]])
+
+    simulator = SimulateNARMAX(
+        model_type="NAR",
+        estimate_parameter=False,
+        basis_function=Polynomial(degree=1, include_bias=include_bias),
+    )
+    n_step = simulator.simulate(
+        X_test=None,
+        y_test=y_integer,
+        model_code=model_code,
+        theta=theta,
+        steps_ahead=2,
+    )
+    free_run = simulator.predict(
+        X=None,
+        y=y_integer[:1],
+        forecast_horizon=4,
+    )
+
+    assert np.issubdtype(n_step.dtype, np.floating)
+    assert np.issubdtype(free_run.dtype, np.floating)
+    np.testing.assert_allclose(n_step, expected_n_step, rtol=1e-12, atol=1e-12)
+    np.testing.assert_allclose(free_run, expected_free_run, rtol=1e-12, atol=1e-12)
+
+
 def test_predict_preserves_array_api_namespace_with_numpy_metadata():
     array_api_strict = pytest.importorskip("array_api_strict")
     _, x_valid_np, _, y_valid_np = _small_siso_dataset()
@@ -801,6 +945,35 @@ def test_predict_n_step_preserves_array_api_namespace_via_cpu_fallback():
 
     assert result.__array_namespace__() is array_api_strict
     xp_assert_allclose(result, expected)
+
+
+def test_nar_integer_n_step_promotes_array_api_output_via_cpu_fallback():
+    array_api_strict = pytest.importorskip("array_api_strict")
+    y_integer_np = np.array([[3], [100], [100], [100], [100]])
+    expected = np.array([[3], [1.5], [0.75], [50], [25]])
+    simulator = SimulateNARMAX(
+        model_type="NAR",
+        estimate_parameter=False,
+        basis_function=Polynomial(degree=1, include_bias=False),
+    )
+    simulator.simulate(
+        X_test=None,
+        y_test=y_integer_np,
+        model_code=np.array([[1001]]),
+        theta=np.array([[0.5]]),
+        steps_ahead=2,
+    )
+
+    with config_context(array_api_dispatch=True):
+        y_integer = array_api_strict.asarray(
+            y_integer_np,
+            dtype=array_api_strict.int64,
+        )
+        result = simulator.predict(X=None, y=y_integer, steps_ahead=2)
+
+    assert result.__array_namespace__() is array_api_strict
+    assert array_api_strict.isdtype(result.dtype, "real floating")
+    xp_assert_allclose(result, expected, rtol=1e-12, atol=1e-12)
 
 
 def test_predict_rejects_mixed_array_api_namespaces():

--- a/sysidentpy/tests/test_include_bias_cross_flows.py
+++ b/sysidentpy/tests/test_include_bias_cross_flows.py
@@ -85,6 +85,89 @@ def _fit_frols_model(basis_function, x_train, y_train):
     ).fit(X=x_train, y=y_train)
 
 
+def _generate_nar_data(n_samples=100):
+    rng = np.random.default_rng(193)
+    y = np.zeros((n_samples, 1))
+    y[:2, 0] = [0.2, -0.1]
+
+    for k in range(2, n_samples):
+        y[k, 0] = 0.55 * y[k - 1, 0] - 0.1 * y[k - 2, 0] + 0.05 + 0.03 * rng.normal()
+
+    return y[:-25], y[-25:]
+
+
+def _fit_frols_nar(y_train, include_bias):
+    return FROLS(
+        ylag=2,
+        xlag=2,
+        model_type="NAR",
+        n_terms=3,
+        order_selection=False,
+        estimator=LeastSquares(),
+        basis_function=Polynomial(degree=2, include_bias=include_bias),
+    ).fit(X=None, y=y_train)
+
+
+def _fit_aols_nar(y_train, include_bias):
+    return AOLS(
+        ylag=2,
+        xlag=2,
+        model_type="NAR",
+        k=3,
+        L=1,
+        estimator=LeastSquares(),
+        basis_function=Polynomial(degree=2, include_bias=include_bias),
+    ).fit(X=None, y=y_train)
+
+
+def _fit_rmss_nar(y_train, include_bias):
+    return RMSS(
+        ylag=2,
+        xlag=2,
+        model_type="NAR",
+        n_terms=3,
+        order_selection=False,
+        estimator=LeastSquares(),
+        basis_function=Polynomial(degree=2, include_bias=include_bias),
+    ).fit(X=None, y=y_train)
+
+
+def _fit_exact_ar1_nar(include_bias):
+    offset = 0.25 if include_bias else 0.0
+    y = np.empty((40, 1))
+    y[0, 0] = 3.0
+    for k in range(1, len(y)):
+        y[k, 0] = 0.5 * y[k - 1, 0] + offset
+
+    return FROLS(
+        ylag=1,
+        xlag=1,
+        model_type="NAR",
+        n_terms=1 + int(include_bias),
+        order_selection=False,
+        estimator=LeastSquares(),
+        basis_function=Polynomial(degree=1, include_bias=include_bias),
+    ).fit(X=None, y=y)
+
+
+def _segmented_nar_free_run_reference(model, y, steps_ahead):
+    reference = np.full_like(y, np.nan)
+    reference[: model.max_lag] = y[: model.max_lag]
+
+    for block_start in range(model.max_lag, len(y), steps_ahead):
+        block_horizon = min(steps_ahead, len(y) - block_start)
+        initial_condition = y[block_start - model.max_lag : block_start]
+        free_run = model.predict(
+            X=None,
+            y=initial_condition,
+            steps_ahead=None,
+            forecast_horizon=block_horizon,
+        )
+        reference[block_start : block_start + block_horizon] = free_run[-block_horizon:]
+
+    return reference
+
+
 def _simulate_metamss(model, **kwargs):
     model.theta = np.ones((len(kwargs["model_code"]), 1))
     model.pivv = np.arange(len(kwargs["model_code"]), dtype=np.intp)
@@ -437,6 +520,120 @@ def test_frols_without_bias_aligns_nar_and_nfir_models(model_type, uses_input):
     assert not np.any(np.all(model.regressor_code == 0, axis=1))
     assert prediction.shape == y_valid.shape
     assert np.all(np.isfinite(prediction))
+
+
+@pytest.mark.parametrize(
+    "steps_ahead",
+    [
+        pytest.param(2, id="two-steps"),
+        pytest.param(3, id="three-steps"),
+        pytest.param(24, id="longer-than-remaining-horizon"),
+    ],
+)
+@pytest.mark.parametrize("include_bias", [True, False])
+def test_frols_nar_n_step_matches_segmented_free_runs(
+    include_bias,
+    steps_ahead,
+):
+    y_train, y_valid = _generate_nar_data()
+    model = _fit_frols_nar(y_train, include_bias)
+    expected = _segmented_nar_free_run_reference(
+        model,
+        y_valid,
+        steps_ahead,
+    )
+
+    prediction = model.predict(
+        X=None,
+        y=y_valid,
+        steps_ahead=steps_ahead,
+    )
+
+    assert prediction.shape == y_valid.shape
+    assert np.all(np.isfinite(prediction))
+    assert_array_equal(prediction[: model.max_lag], y_valid[: model.max_lag])
+    assert_allclose(prediction, expected, rtol=1e-12, atol=1e-12)
+    assert_allclose(prediction[-1], expected[-1], rtol=1e-12, atol=1e-12)
+
+
+@pytest.mark.parametrize("include_bias", [True, False])
+def test_frols_nar_one_step_and_free_run_regressions(include_bias):
+    y_train, y_valid = _generate_nar_data()
+    model = _fit_frols_nar(y_train, include_bias)
+    remaining_horizon = int(len(y_valid) - model.max_lag)
+
+    one_step = model.predict(X=None, y=y_valid, steps_ahead=1)
+    one_step_reference = _segmented_nar_free_run_reference(model, y_valid, 1)
+    free_run = model.predict(
+        X=None,
+        y=y_valid[: model.max_lag],
+        forecast_horizon=remaining_horizon,
+    )
+    free_run_reference = _segmented_nar_free_run_reference(
+        model,
+        y_valid,
+        remaining_horizon + 1,
+    )
+
+    assert one_step.shape == y_valid.shape
+    assert free_run.shape == y_valid.shape
+    assert np.all(np.isfinite(one_step))
+    assert np.all(np.isfinite(free_run))
+    assert_array_equal(one_step[: model.max_lag], y_valid[: model.max_lag])
+    assert_array_equal(free_run[: model.max_lag], y_valid[: model.max_lag])
+    assert_allclose(one_step, one_step_reference, rtol=1e-12, atol=1e-12)
+    assert_allclose(free_run, free_run_reference, rtol=1e-12, atol=1e-12)
+
+
+@pytest.mark.parametrize("include_bias", [True, False])
+def test_frols_nar_recursive_predictions_promote_integer_output(include_bias):
+    model = _fit_exact_ar1_nar(include_bias)
+    y_integer = np.array([[3], [100], [100], [100], [100]])
+
+    if include_bias:
+        expected_one_step = np.array([[3], [1.75], [50.25], [50.25], [50.25]])
+        expected_n_step = np.array([[3], [1.75], [1.125], [50.25], [25.375]])
+        expected_free_run = np.array([[3], [1.75], [1.125], [0.8125], [0.65625]])
+    else:
+        expected_one_step = np.array([[3], [1.5], [50], [50], [50]])
+        expected_n_step = np.array([[3], [1.5], [0.75], [50], [25]])
+        expected_free_run = np.array([[3], [1.5], [0.75], [0.375], [0.1875]])
+
+    one_step = model.predict(X=None, y=y_integer, steps_ahead=1)
+    n_step = model.predict(X=None, y=y_integer, steps_ahead=2)
+    free_run = model.predict(X=None, y=y_integer[:1], forecast_horizon=4)
+
+    assert np.issubdtype(one_step.dtype, np.floating)
+    assert np.issubdtype(n_step.dtype, np.floating)
+    assert np.issubdtype(free_run.dtype, np.floating)
+    assert_allclose(one_step, expected_one_step, rtol=1e-12, atol=1e-12)
+    assert_allclose(n_step, expected_n_step, rtol=1e-12, atol=1e-12)
+    assert_allclose(free_run, expected_free_run, rtol=1e-12, atol=1e-12)
+
+
+@pytest.mark.parametrize(
+    "fit_model",
+    [
+        pytest.param(_fit_aols_nar, id="aols"),
+        pytest.param(_fit_rmss_nar, id="rmss"),
+    ],
+)
+@pytest.mark.parametrize("include_bias", [True, False])
+def test_base_mss_nar_consumers_match_segmented_free_runs(
+    fit_model,
+    include_bias,
+):
+    y_train, y_valid = _generate_nar_data()
+    model = fit_model(y_train, include_bias)
+    expected = _segmented_nar_free_run_reference(model, y_valid, 3)
+
+    prediction = model.predict(X=None, y=y_valid, steps_ahead=3)
+
+    assert prediction.shape == y_valid.shape
+    assert np.all(np.isfinite(prediction))
+    assert_array_equal(prediction[: model.max_lag], y_valid[: model.max_lag])
+    assert_allclose(prediction, expected, rtol=1e-12, atol=1e-12)
+    assert_allclose(prediction[-2:], expected[-2:], rtol=1e-12, atol=1e-12)
 
 
 def test_rmss_without_bias_keeps_selection_and_parameters_aligned():

--- a/sysidentpy/tests/test_narmax_base.py
+++ b/sysidentpy/tests/test_narmax_base.py
@@ -22,6 +22,7 @@ from sysidentpy.basis_function import (
     Polynomial,
 )
 from sysidentpy.tests._array_api_asserts import (
+    assert_allclose as xp_assert_allclose,
     assert_array_equal as xp_assert_array_equal,
 )
 from sysidentpy.model_structure_selection import FROLS
@@ -825,24 +826,83 @@ def test_nar_step_ahead_insufficient_initial_conditions():
         model._nar_step_ahead(y[0], steps_ahead=2)
 
 
+@pytest.mark.parametrize("steps_ahead", [0, -1])
+def test_nar_step_ahead_rejects_non_positive_steps(steps_ahead):
+    model = RecordingPredictableMSS(model_type="NAR")
+    y_segment = np.arange(model.max_lag + 1, dtype=float).reshape(-1, 1)
+
+    with pytest.raises(
+        ValueError,
+        match="steps_ahead must be integer and > zero",
+    ):
+        model._nar_step_ahead(y_segment, steps_ahead=steps_ahead)
+
+
 def test_nar_step_ahead_handles_multiple_segments():
-    model = PredictableMSS(model_type="NAR")
-    y_segment = np.arange(model.max_lag + 4, dtype=float).reshape(-1, 1)
+    model = RecordingPredictableMSS(model_type="NAR")
+    y_segment = np.arange(model.max_lag + 5, dtype=float).reshape(-1, 1)
 
     result = model._nar_step_ahead(y_segment, steps_ahead=2)
 
-    expected_rows = y_segment.shape[0] + 2 - model.max_lag
-    assert result.shape == (expected_rows, 1)
+    assert result.shape == (y_segment.shape[0] - model.max_lag, 1)
+    assert_array_equal(result[:, 0], np.array([0.0, 1.0, 0.0, 1.0, 0.0]))
+    assert [call[2] for call in model.prediction_calls] == [2, 2, 1]
+    assert [call[0] for call in model.prediction_calls] == [None, None, None]
+    for block, call in enumerate(model.prediction_calls):
+        start = block * 2
+        assert_array_equal(call[1], y_segment[start : start + model.max_lag])
 
 
 def test_nar_step_ahead_handles_single_segment():
+    model = RecordingPredictableMSS(model_type="NAR")
+    y_segment = np.arange(model.max_lag + 3, dtype=float).reshape(-1, 1)
+
+    result = model._nar_step_ahead(y_segment, steps_ahead=10)
+
+    assert result.shape == (3, 1)
+    assert_array_equal(result[:, 0], np.arange(3, dtype=float))
+    assert len(model.prediction_calls) == 1
+    assert model.prediction_calls[0][2] == 3
+    assert_array_equal(model.prediction_calls[0][1], y_segment[: model.max_lag])
+
+
+def test_nar_step_ahead_with_only_initial_conditions_returns_empty_prediction():
+    model = RecordingPredictableMSS(model_type="NAR")
+    y_initial = np.arange(model.max_lag, dtype=float).reshape(-1, 1)
+
+    result = model._nar_step_ahead(y_initial, steps_ahead=3)
+
+    assert result.shape == (0, 1)
+    assert model.prediction_calls == []
+
+
+def test_nar_step_ahead_preserves_fractional_predictions_for_integer_output():
+    model = RecordingPredictableMSS(model_type="NAR", prediction_offset=0.5)
+    y_segment = np.arange(model.max_lag + 3, dtype=int).reshape(-1, 1)
+
+    result = model._nar_step_ahead(y_segment, steps_ahead=2)
+
+    assert np.issubdtype(result.dtype, np.floating)
+    np.testing.assert_allclose(result[:, 0], np.array([0.5, 1.5, 0.5]))
+
+
+def test_narmax_predict_reference_promotes_integer_array_api_inputs():
+    xp = pytest.importorskip("array_api_strict")
     model = PredictableMSS(model_type="NAR")
-    y_segment = np.arange(model.max_lag + 1, dtype=float).reshape(-1, 1)
+    model.n_inputs = 0
+    model.theta = np.array([[0.6]])
+    y_initial = xp.asarray([[1], [2]], dtype=xp.int64)
 
-    result = model._nar_step_ahead(y_segment, steps_ahead=y_segment.shape[0])
+    with config_context(array_api_dispatch=True):
+        result = model._narmax_predict_reference(
+            x=None,
+            y_initial=y_initial,
+            forecast_horizon=5,
+        )
 
-    expected_rows = y_segment.shape[0] * 2 - model.max_lag
-    assert result.shape == (expected_rows, 1)
+    assert result.__array_namespace__() is xp
+    assert xp.isdtype(result.dtype, "real floating")
+    xp_assert_allclose(result, np.array([[1.2], [0.72], [0.432]]))
 
 
 def test_narmarx_step_ahead_insufficient_initial_conditions():
@@ -1060,6 +1120,25 @@ class PredictableMSS(BaseMSS):
     ) -> np.ndarray:
         _ = (X, y, steps_ahead, forecast_horizon)
         return np.zeros((1, 1))
+
+
+class RecordingPredictableMSS(PredictableMSS):
+    """Predictable BaseMSS variant that records recursive NAR blocks."""
+
+    def __init__(self, model_type="NAR", prediction_offset=0.0):
+        super().__init__(model_type=model_type)
+        self.prediction_calls = []
+        self.prediction_offset = prediction_offset
+
+    def _model_prediction(
+        self,
+        x: Optional[np.ndarray],
+        y_initial: np.ndarray,
+        forecast_horizon: int = 1,
+    ) -> np.ndarray:
+        self.prediction_calls.append((x, y_initial.copy(), forecast_horizon))
+        prediction = super()._model_prediction(x, y_initial, forecast_horizon)
+        return prediction + self.prediction_offset
 
 
 class ArrayAPIPredictableMSS(PredictableMSS):


### PR DESCRIPTION
- compute exact block horizons without internal padding
- reuse shared NAR step-ahead logic in General NARX and NARXNN
- validate step sizes and preserve fractional predictions for integer NAR data
- cover partial blocks, bias modes, shared consumers, and Array API fallback